### PR TITLE
Temporarily patch FieldMask ToJsonString method

### DIFF
--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -23,9 +23,10 @@ import json
 import google.api_core.grpc_helpers
 import google.auth.transport.requests
 import google.oauth2.credentials
-import google.ads.google_ads.errors
+from google.ads.google_ads import errors, util
 from google.ads.google_ads.v0.proto.errors import errors_pb2 as error_protos
 from google.protobuf.json_format import MessageToJson
+from google.protobuf import field_mask_pb2 as field_mask
 import grpc
 
 _logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ _PROTO_TEMPLATE = '%s_pb2'
 _DEFAULT_TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
 _DEFAULT_VERSION = 'v0'
 
+util.patch_to_json_method(field_mask.FieldMask)
 
 class GoogleAdsClient(object):
     """Google Ads client used to configure settings and fetch services."""
@@ -303,7 +305,7 @@ class ExceptionInterceptor(grpc.UnaryUnaryClientInterceptor):
             if google_ads_failure:
                 request_id = self._get_request_id(trailing_metadata)
 
-                raise google.ads.google_ads.errors.GoogleAdsException(
+                raise errors.GoogleAdsException(
                     exception, response, google_ads_failure, request_id)
             else:
                 # Raise the original exception if not a GoogleAdsFailure.

--- a/google/ads/google_ads/util.py
+++ b/google/ads/google_ads/util.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 
-# TODO - Remove implementation of MonkeyPatching ToJsonString once issue
+# TODO - Remove patching ToJsonString once issue
 # has been addressed in the protobuf library.
 def patch_to_json_method(obj):
-    """Monkey patches an object's ToJsonString method.
+    """Patches an object's ToJsonString method.
 
     Args:
-        obj: An arbitrary object.isinstance
+        obj: An arbitrary object.
     """
     obj.ToJsonString = _patched_to_json_string
 
 
 def _patched_to_json_string(self):
-    """Converts an objects paths array to a camel cased string."""
+    """Converts all string in an objects paths array to camel case."""
     try:
         iter(self.paths)
     except TypeError:
@@ -46,6 +46,12 @@ def _snake_case_to_camel_case(path_name):
 
   This is a slightly modified version of the function defined in the protobuf
   library here: https://github.com/protocolbuffers/protobuf/blob/master/python/google/protobuf/internal/well_known_types.py#L506
+
+  Args:
+    path_name: a str, typically a path from a FieldMask messages "paths" list.
+
+  Returns:
+    A camel cased str.
   """
   result = []
   after_underscore = False

--- a/google/ads/google_ads/util.py
+++ b/google/ads/google_ads/util.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# TODO - Remove implementation of MonkeyPatching ToJsonString once issue
+# has been addressed in the protobuf library.
+def patch_to_json_method(obj):
+    """Monkey patches an object's ToJsonString method.
+
+    Args:
+        obj: An arbitrary object.isinstance
+    """
+    obj.ToJsonString = _patched_to_json_string
+
+
+def _patched_to_json_string(self):
+    """Converts an objects paths array to a camel cased string."""
+    try:
+        iter(self.paths)
+    except TypeError:
+        paths = []
+    else:
+        paths = self.paths
+
+    camelcase_paths = []
+
+    for path in paths:
+        camelcase_paths.append(_snake_case_to_camel_case(path))
+
+    return ','.join(camelcase_paths)
+
+
+def _snake_case_to_camel_case(path_name):
+  """Converts a path name from snake_case to camelCase.
+
+  This is a slightly modified version of the function defined in the protobuf
+  library here: https://github.com/protocolbuffers/protobuf/blob/master/python/google/protobuf/internal/well_known_types.py#L506
+  """
+  result = []
+  after_underscore = False
+  for c in path_name:
+    if c.isupper():
+      raise Error('Fail to print FieldMask to Json string: Path name '
+                  '{0} must not contain uppercase letters.'.format(path_name))
+    if after_underscore:
+      if c.islower() or c.isdigit():
+        result.append(c.upper())
+        after_underscore = False
+      else:
+        raise Error('Fail to print FieldMask to Json string: The '
+                    'character after a "_" must be a lowercase letter '
+                    'in path name {0}.'.format(path_name))
+    elif c == '_':
+      after_underscore = True
+    else:
+      result += c
+
+  if after_underscore:
+    raise Error('Fail to print FieldMask to Json string: Trailing "_" '
+                'in path name {0}.'.format(path_name))
+  return ''.join(result)
+

--- a/google/ads/google_ads/util.py
+++ b/google/ads/google_ads/util.py
@@ -66,7 +66,7 @@ def _snake_case_to_camel_case(path_name):
       else:
         raise Error('Fail to print FieldMask to Json string: The '
                     'character after a "_" must be a lowercase letter '
-                    'in path name {0}.'.format(path_name))
+                    'or digit in path name {0}.'.format(path_name))
     elif c == '_':
       after_underscore = True
     else:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -27,3 +27,27 @@ class UtilsTest(TestCase):
         mock_obj = mock.Mock()
         util.patch_to_json_method(mock_obj)
         self.assertTrue(callable(mock_obj.ToJsonString))
+
+    def test_patch_to_json_returns_string(self):
+        mock_obj = mock.Mock()
+        util.patch_to_json_method(mock_obj)
+        self.assertIsInstance(mock_obj.ToJsonString(mock_obj), str)
+
+    def test_patch_to_json_stringifies_paths(self):
+        mock_obj = mock.Mock()
+        mock_obj.paths = ['hello', 'goodbye']
+        util.patch_to_json_method(mock_obj)
+        self.assertEqual(mock_obj.ToJsonString(mock_obj), 'hello,goodbye')
+
+    def test_patch_to_json_camel_cases_paths(self):
+        mock_obj = mock.Mock()
+        mock_obj.paths = ['hello', '_test_test_test']
+        util.patch_to_json_method(mock_obj)
+        self.assertEqual(mock_obj.ToJsonString(mock_obj), 'hello,TestTestTest')
+
+    def test_path_to_json_camel_cases_digits(self):
+        mock_obj = mock.Mock()
+        mock_obj.paths = ['hello', '_test_25_test']
+        util.patch_to_json_method(mock_obj)
+        self.assertEqual(mock_obj.ToJsonString(mock_obj), 'hello,Test25Test')
+

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Google Ads API client util module."""
+
+import mock
+from unittest import TestCase
+
+import google.ads.google_ads.util as util
+
+
+class UtilsTest(TestCase):
+    def test_patch_to_json_method_callable(self):
+        self.assertTrue(callable(util.patch_to_json_method))
+
+    def test_patch_to_json_method_augments(self):
+        mock_obj = mock.Mock()
+        util.patch_to_json_method(mock_obj)
+        self.assertTrue(callable(mock_obj.ToJsonString))


### PR DESCRIPTION
This is a temporary patch to fix [this Issue](https://github.com/googleads/google-ads-python/issues/30) until one of two things happens:

1. We refactor the logging library to not rely on serializing messages to JSON.
2. A permanent fix is introduced into the Python protobuf library.