### PR TITLE
Install googleapis-common-protos to support LROs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* 1.1.0:
+- Install googleapis-common-protos to expose google.longrunning for LRO
+support.
+
 * 1.0.1:
 - Fix bug in import path from issues #45 and #44.
 

--- a/google/ads/google_ads/__init__.py
+++ b/google/ads/google_ads/__init__.py
@@ -20,4 +20,4 @@ import google.ads.google_ads.client
 import google.ads.google_ads.errors
 
 
-VERSION = '1.0.1'
+VERSION = '1.1.0'

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
     'enum34; python_version < "3.4"',
     'google-auth-oauthlib >= 0.0.1, < 1.0.0',
     'google-api-core == 1.7.0',
+    'googleapis-common-protos >= 1.5.8, < 2.0.0',
     'grpcio == 1.18.0',
     'PyYAML >= 4.2b1, < 5.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name='google-ads',
-    version='1.0.1',
+    version='1.1.0',
     author='Google LLC',
     author_email='googleapis-packages@google.com',
     classifiers=[


### PR DESCRIPTION
Imports the `google.longrunning` module, which is used [here](https://github.com/googleads/google-ads-python/blob/master/google/ads/google_ads/v1/proto/services/mutate_job_service_pb2.py#L18) for LROs. 