### PR TITLE
Remove JSON serialization of Proto messages

### DIFF
--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -455,7 +455,7 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
         return getattr(request, 'customer_id', None)
 
     def _parse_exception_to_str(self, exception):
-        """Parses response object to JSON.
+        """Parses response object to str for logging.
 
         Returns:
             A str representing a response or exception from the

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -371,7 +371,13 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             response: A grpc.Call/grpc.Future instance.
         """
         try:
-            return response.trailing_metadata()
+            trailing_metadata = response.trailing_metadata()
+
+            if not trailing_metadata:
+                return _get_trailing_metadata_from_interceptor_exception(
+                    response.exception())
+
+            return trailing_metadata
         except AttributeError:
             return _get_trailing_metadata_from_interceptor_exception(
                 response.exception())

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -470,7 +470,7 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             failure = getattr(exception, 'failure', None)
 
             if failure:
-                return _parse_message_to_json(failure)
+                return failure
             else:
                 # if exception.failure isn't present then it's likely this is a
                 # transport error with a .debug_error_string method.
@@ -482,7 +482,7 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
                     # then simply return an empty JSON string
                     return '{}'
         else:
-            return _parse_message_to_json(response.result())
+            return response.result()
 
     def _get_fault_message(self, exception):
         """Retrieves a fault/error message from an exception object.
@@ -526,9 +526,8 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
                      method, request_id, False, None))
 
     def _log_failed_request(self, method, customer_id, metadata_json,
-                            request_id, request_json,
-                            trailing_metadata_json, response_json,
-                            fault_message):
+                            request_id, request, trailing_metadata_json,
+                            response_json, fault_message):
         """Handles logging of a failed request.
 
         Args:
@@ -536,13 +535,13 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             customer_id: The customer ID associated with the request.
             metadata_json: A JSON str of initial_metadata.
             request_id: A unique ID for the request provided in the response.
-            request_json: A JSON str of the request message.
+            request: An instance of a request proto message.
             trailing_metadata_json: A JSON str of trailing_metadata.
             response_json: A JSON str of the the response message.
             fault_message: A str error message from a failed request.
         """
         _logger.info(self._FULL_FAULT_LOG_LINE % (method, self.endpoint,
-                     metadata_json, request_json, trailing_metadata_json,
+                     metadata_json, request, trailing_metadata_json,
                      response_json))
 
         _logger.warning(self._SUMMARY_LOG_LINE % (customer_id, self.endpoint,

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -25,7 +25,6 @@ import google.api_core.grpc_helpers
 import google.auth.transport.requests
 import google.oauth2.credentials
 import google.ads.google_ads.errors
-from google.protobuf.json_format import MessageToJson
 import grpc
 
 _logger = logging.getLogger(__name__)
@@ -744,15 +743,3 @@ def _parse_metadata_to_json(metadata):
             metadata_dict[key] = value
 
     return _parse_to_json(metadata_dict)
-
-
-def _parse_message_to_json(message):
-    """Parses a gRPC request object to a JSON string.
-
-    Args:
-        request: an instance of a request proto message, for example
-            a SearchGoogleAdsRequest or a MutateAdGroupAdsRequest.
-    """
-    json = MessageToJson(message)
-    json = json.replace(', \n', ',\n')
-    return json

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -375,7 +375,7 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
         if logging_config:
             logging.config.dictConfig(logging_config)
 
-    def _get_request_id(self, response, exception):
+    def _get_request_id(self, response):
         """Retrieves the request id from a response object.
 
         Returns:
@@ -384,10 +384,9 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
 
         Args:
             response: A grpc.Call/grpc.Future instance.
-            exception: A grpc.Call instance.
         """
-        if exception:
-            return getattr(exception, 'request_id', None)
+        if response.exception():
+            return getattr(response.exception(), 'request_id', None)
         else:
             trailing_metadata = response.trailing_metadata()
             for datum in trailing_metadata:
@@ -555,12 +554,12 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             request: An instance of a request proto message.
             response: A grpc.Call/grpc.Future instance.
         """
-        exception = response.exception()
         method = self._get_call_method(client_call_details)
         customer_id = self._get_customer_id(request)
         initial_metadata = self._get_initial_metadata(client_call_details)
         initial_metadata_json = _parse_metadata_to_json(initial_metadata)
-        request_id = self._get_request_id(response, exception)
+        request_id = self._get_request_id(response)
+        exception = response.exception()
         trailing_metadata = self._get_trailing_metadata(response, exception)
         trailing_metadata_json = _parse_metadata_to_json(trailing_metadata)
 

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -547,15 +547,15 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
         _logger.warning(self._SUMMARY_LOG_LINE % (customer_id, self.endpoint,
                         method, request_id, True, fault_message))
 
-    def _log_request(self, client_call_details, request, response, exception):
+    def _log_request(self, client_call_details, request, response):
         """Handles logging all requests.
 
         Args:
             client_call_details: An instance of grpc.ClientCallDetails.
             request: An instance of a request proto message.
             response: A grpc.Call/grpc.Future instance.
-            exception: A grpc.Call instance.
         """
+        exception = response.exception()
         method = self._get_call_method(client_call_details)
         customer_id = self._get_customer_id(request)
         initial_metadata = self._get_initial_metadata(client_call_details)
@@ -586,11 +586,9 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             A grpc.Call/grpc.Future instance representing a service response.
         """
         response = continuation(client_call_details, request)
-        if _logger.isEnabledFor(logging.WARNING):
-            exception = response.exception()
 
-            self._log_request(client_call_details, request, response,
-                              exception)
+        if _logger.isEnabledFor(logging.WARNING):
+            self._log_request(client_call_details, request, response)
 
         return response
 

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -434,17 +434,17 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             exception: A grpc.Call instance.
         """
         try:
-            # If the exception is from the Google Ads API the failure attribute
-            # will be an instance of GoogleAdsFailure and can be concatenated
-            # into a log string.
+            # If the exception is from the Google Ads API then the failure
+            # attribute will be an instance of GoogleAdsFailure and can be
+            # concatenated into a log string.
             return exception.failure
         except AttributeError:
             try:
                 # if exception.failure isn't present then it's likely this is a
                 # transport error with a .debug_error_string method and the
                 # returned JSON string will need to be formatted.
-                debug_string = exception.debug_error_string()
-                return _format_json_object(json.loads(debug_string))
+                return _format_json_object(json.loads(
+                    exception.debug_error_string()))
             except (AttributeError, ValueError):
                 # if both attempts to retrieve serializable error data fail
                 # then simply return an empty JSON string

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -419,11 +419,10 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
         return getattr(request, 'customer_id', None)
 
     def _parse_exception_to_str(self, exception):
-        """Parses response object to str for logging.
+        """Parses response exception object to str for logging.
 
         Returns:
-            A str representing a response or exception from the
-            service.
+            A str representing a exception from the API.
 
         Args:
             exception: A grpc.Call instance.
@@ -500,12 +499,12 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
             trailing_metadata_json: A JSON str of trailing_metadata.
             response: A JSON str of the the response message.
         """
-        response_json = self._parse_exception_to_str(response.exception())
+        exception_str = self._parse_exception_to_str(response.exception())
         fault_message = self._get_fault_message(response.exception())
 
         _logger.info(self._FULL_FAULT_LOG_LINE.format(method, self.endpoint,
                      metadata_json, request, trailing_metadata_json,
-                     response_json))
+                     exception_str))
 
         _logger.warning(self._SUMMARY_LOG_LINE.format(customer_id, self.endpoint,
                         method, request_id, True, fault_message))

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -473,7 +473,7 @@ class LoggingInterceptor(grpc.UnaryUnaryClientInterceptor):
                 # transport error with a .debug_error_string method and the
                 # returned JSON string will need to be formatted.
                 debug_string = exception.debug_error_string()
-                return _parse_to_json(json.loads(debug_string))
+                return _format_json_object(json.loads(debug_string))
             except (AttributeError, ValueError):
                 # if both attempts to retrieve serializable error data fail
                 # then simply return an empty JSON string
@@ -696,7 +696,7 @@ def _validate_login_customer_id(login_customer_id):
                              'as a string, i.e. "1234567890"')
 
 
-def _parse_to_json(obj):
+def _format_json_object(obj):
     """Parses a serializable object into a consistently formatted JSON string.
 
     Returns:
@@ -737,4 +737,4 @@ def _parse_metadata_to_json(metadata):
             value = datum[1]
             metadata_dict[key] = value
 
-    return _parse_to_json(metadata_dict)
+    return _format_json_object(metadata_dict)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -456,6 +456,7 @@ class LoggingInterceptorTest(TestCase):
     _MOCK_ERROR_MESSAGE = 'Test error message'
     _MOCK_TRANSPORT_ERROR_MESSAGE = u'Received RST_STREAM with error code 2'
     _MOCK_DEBUG_ERROR_STRING = u'{"description":"Error received from peer"}'
+    _MOCK_RESPONSE_MSG = 'test response msg'
 
     def _create_test_interceptor(self, config=_MOCK_CONFIG,
                                  endpoint=_MOCK_ENDPOINT):
@@ -574,9 +575,13 @@ class LoggingInterceptorTest(TestCase):
                 return self._get_mock_exception()
             return None
 
+        def mock_result_fn():
+            return self._MOCK_RESPONSE_MSG
+
         mock_response = mock.Mock()
         mock_response.exception = mock_exception_fn
         mock_response.trailing_metadata = self._get_trailing_metadata_fn()
+        mock_response.result = mock_result_fn
         return mock_response
 
     def _get_mock_continuation_fn(self, fail=False):
@@ -677,7 +682,7 @@ class LoggingInterceptorTest(TestCase):
             mock_logger.debug.assert_called_once_with(
                 interceptor._FULL_REQUEST_LOG_LINE
                 % (self._MOCK_METHOD, self._MOCK_ENDPOINT, initial_metadata,
-                    mock_request, trailing_metadata, mock_response))
+                    mock_request, trailing_metadata, mock_response.result()))
 
     def test_intercept_unary_unary_failed_request(self):
         """_logger.warning and _logger.info should be called.

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -789,51 +789,29 @@ class LoggingInterceptorTest(TestCase):
             result = interceptor._get_request_id(mock_response, mock_exception)
             self.assertEqual(result, None)
 
-#    def test_parse_response_to_json(self):
-#        """Calls MessageToJson with a successful response message."""
-#        with mock.patch('logging.config.dictConfig'), \
-#            mock.patch(
-#                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
-#            mock_response = self._get_mock_response()
-#            mock_exception = mock_response.exception()
-#            interceptor = self._create_test_interceptor()
-#            interceptor._parse_response_to_json(mock_response, mock_exception)
-#            mock_formatter.assert_called_once_with(mock_response.result())
+    def test_parse_response_to_json_transport_failure(self):
+        """ Calls _parse_to_json with transport error's debug_error_string."""
+        with mock.patch('logging.config.dictConfig'), \
+            mock.patch(
+                'google.ads.google_ads.client._parse_to_json') as mock_parser:
+            mock_response = mock.Mock()
+            mock_exception = self._get_mock_transport_exception()
+            interceptor = self._create_test_interceptor()
+            interceptor._parse_response_to_json(mock_response, mock_exception)
+            mock_parser.assert_called_once_with(
+                json.loads(self._MOCK_DEBUG_ERROR_STRING))
 
-#    def test_parse_response_to_json_google_ads_failure(self):
-#        """Calls MessageToJson with a GoogleAdsException."""
-#        with mock.patch('logging.config.dictConfig'), \
-#            mock.patch(
-#                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
-#            mock_response = mock.Mock()
-#            mock_exception = self._get_mock_exception()
-#            interceptor = self._create_test_interceptor()
-#            interceptor._parse_response_to_json(mock_response, mock_exception)
-#            mock_formatter.assert_called_once_with(mock_exception.failure)
-
-#    def test_parse_response_to_json_transport_failure(self):
-#        """ Calls _parse_to_json with transport error's debug_error_string."""
-#        with mock.patch('logging.config.dictConfig'), \
-#            mock.patch(
-#                'google.ads.google_ads.client._parse_to_json') as mock_parser:
-#            mock_response = mock.Mock()
-#            mock_exception = self._get_mock_transport_exception()
-#            interceptor = self._create_test_interceptor()
-#            interceptor._parse_response_to_json(mock_response, mock_exception)
-#            mock_parser.assert_called_once_with(
-#                json.loads(self._MOCK_DEBUG_ERROR_STRING))
-
-#    def test_parse_response_to_json_unknown_failure(self):
-#        """Returns an empty JSON string if nothing can be parsed to JSON."""
-#        with mock.patch('logging.config.dictConfig'):
-#            mock_response = mock.Mock()
-#            mock_exception = mock.Mock()
-#            del mock_exception.failure
-#            del mock_exception.debug_error_string
-#            interceptor = self._create_test_interceptor()
-#            result = interceptor._parse_response_to_json(
-#                mock_response, mock_exception)
-#            self.assertEqual(result, '{}')
+    def test_parse_response_to_json_unknown_failure(self):
+        """Returns an empty JSON string if nothing can be parsed to JSON."""
+        with mock.patch('logging.config.dictConfig'):
+            mock_response = mock.Mock()
+            mock_exception = mock.Mock()
+            del mock_exception.failure
+            del mock_exception.debug_error_string
+            interceptor = self._create_test_interceptor()
+            result = interceptor._parse_response_to_json(
+                mock_response, mock_exception)
+            self.assertEqual(result, '{}')
 
     def test_get_trailing_metadata(self):
         """Retrieves metadata from a response object."""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -25,11 +25,11 @@ from importlib import import_module
 import grpc
 from pyfakefs.fake_filesystem_unittest import TestCase as FileTestCase
 
-import google.ads.google_ads.client
+from google.ads.google_ads import client as Client
 from google.ads.google_ads.errors import GoogleAdsException
 
-latest_version = google.ads.google_ads.client._DEFAULT_VERSION
-valid_versions = google.ads.google_ads.client._VALID_API_VERSIONS
+latest_version = Client._DEFAULT_VERSION
+valid_versions = Client._VALID_API_VERSIONS
 
 errors = import_module('google.ads.google_ads.%s.proto.errors' % latest_version)
 error_protos = errors.errors_pb2
@@ -46,8 +46,7 @@ class ModuleLevelTest(TestCase):
             ('developer-token', '0000000000'),
             ('login-customer-id', '9999999999')]
 
-        result = (google.ads.google_ads.client.
-                  _parse_metadata_to_json(mock_metadata))
+        result = (Client._parse_metadata_to_json(mock_metadata))
 
         self.assertEqual(result, '{\n'
                                  '  "developer-token": "REDACTED",\n'
@@ -59,23 +58,20 @@ class ModuleLevelTest(TestCase):
     def test_parse_metadata_to_json_with_none(self):
         mock_metadata = None
 
-        result = (google.ads.google_ads.client.
-                  _parse_metadata_to_json(mock_metadata))
+        result = (Client._parse_metadata_to_json(mock_metadata))
 
         self.assertEqual(result, '{}')
 
     def test_get_request_id_from_metadata(self):
-        """_get_request_id obtains a request ID from a metadata tuple"""
+        """Ensures request-id is retrieved from metadata tuple."""
         mock_metadata = (('request-id', '123456'),)
-        result = (google.ads.google_ads.client.
-                  _get_request_id_from_metadata(mock_metadata))
+        result = (Client._get_request_id_from_metadata(mock_metadata))
         self.assertEqual(result, '123456')
 
     def test_get_request_id_no_id(self):
-        """Returns None if the given metadata does not contain a request ID."""
+        """Ensures None is returned if metadata does't contain a request ID."""
         mock_metadata = (('another-key', 'another-val'),)
-        result = (google.ads.google_ads.client.
-                  _get_request_id_from_metadata(mock_metadata))
+        result = (Client._get_request_id_from_metadata(mock_metadata))
         self.assertEqual(result, None)
 
 
@@ -89,9 +85,8 @@ class GoogleAdsClientTest(FileTestCase):
             mock_credentials_instance.refresh_token = self.refresh_token
             mock_credentials_instance.client_id = self.client_id
             mock_credentials_instance.client_secret = self.client_secret
-            client = google.ads.google_ads.client.GoogleAdsClient(
-                mock_credentials_instance, self.developer_token,
-                endpoint=endpoint)
+            client = Client.GoogleAdsClient(mock_credentials_instance,
+                self.developer_token, endpoint=endpoint)
             return client
 
     def setUp(self):
@@ -121,7 +116,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
-            (google.ads.google_ads.client.GoogleAdsClient.load_from_storage())
+            Client.GoogleAdsClient.load_from_storage()
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,
@@ -148,7 +143,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
-            (google.ads.google_ads.client.GoogleAdsClient.load_from_storage())
+            Client.GoogleAdsClient.load_from_storage()
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,
@@ -174,7 +169,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_credentials.return_value = mock_credentials_instance
             self.assertRaises(
                     ValueError,
-                    google.ads.google_ads.client.GoogleAdsClient
+                    Client.GoogleAdsClient
                     .load_from_storage)
 
     def test_load_from_storage_too_short_login_customer_id(self):
@@ -195,7 +190,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_credentials.return_value = mock_credentials_instance
             self.assertRaises(
                     ValueError,
-                    google.ads.google_ads.client.GoogleAdsClient
+                    Client.GoogleAdsClient
                     .load_from_storage)
 
     def test_load_from_storage(self):
@@ -216,8 +211,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
-            (google.ads.google_ads.client.GoogleAdsClient
-             .load_from_storage())
+            Client.GoogleAdsClient.load_from_storage()
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,
@@ -245,7 +239,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
-            google.ads.google_ads.client.GoogleAdsClient.load_from_storage()
+            Client.GoogleAdsClient.load_from_storage()
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,
@@ -271,8 +265,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
-            (google.ads.google_ads.client.GoogleAdsClient
-             .load_from_storage(path=file_path))
+            Client.GoogleAdsClient.load_from_storage(path=file_path)
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,
@@ -285,7 +278,7 @@ class GoogleAdsClientTest(FileTestCase):
 
         self.assertRaises(
             IOError,
-            google.ads.google_ads.client.GoogleAdsClient.load_from_storage,
+            Client.GoogleAdsClient.load_from_storage,
             path=wrong_file_path)
 
     def test_load_from_storage_required_config_missing(self):
@@ -300,7 +293,7 @@ class GoogleAdsClientTest(FileTestCase):
 
         self.assertRaises(
             ValueError,
-            google.ads.google_ads.client.GoogleAdsClient.load_from_storage,
+            Client.GoogleAdsClient.load_from_storage,
             path=file_path)
 
     def test_get_service(self):
@@ -325,7 +318,7 @@ class GoogleAdsClientTest(FileTestCase):
         grpc_transport_module_name = '%s_grpc_transport' % service_module_base
         transport_create_channel_path = (
             'google.ads.google_ads.%s.services.transports.%s.%s.create_channel'
-            % (google.ads.google_ads.client._DEFAULT_VERSION,
+            % (Client._DEFAULT_VERSION,
                grpc_transport_module_name,
                grpc_transport_class_name))
         endpoint = 'alt.endpoint.com'
@@ -366,17 +359,17 @@ class GoogleAdsClientTest(FileTestCase):
 
             # Iterate through retrieval of all types by name.
             for name in type_names:
-                google.ads.google_ads.client.GoogleAdsClient.get_type(
+                Client.GoogleAdsClient.get_type(
                     name, version=ver)
 
     def test_get_type_not_found(self):
         self.assertRaises(
-            ValueError, google.ads.google_ads.client.GoogleAdsClient.get_type,
+            ValueError, Client.GoogleAdsClient.get_type,
             'BadType')
 
     def test_get_type_invalid_version(self):
         self.assertRaises(
-            ValueError, google.ads.google_ads.client.GoogleAdsClient.get_type,
+            ValueError, Client.GoogleAdsClient.get_type,
             'GoogleAdsFailure', version='bad_version')
 
 
@@ -387,7 +380,7 @@ class MetadataInterceptorTest(TestCase):
         self.mock_login_customer_id = '0987654321'
 
     def test_init(self):
-        interceptor = google.ads.google_ads.client.MetadataInterceptor(
+        interceptor = Client.MetadataInterceptor(
             self.mock_developer_token,
             self.mock_login_customer_id)
 
@@ -401,7 +394,7 @@ class MetadataInterceptorTest(TestCase):
         )
 
     def test_init_no_login_customer_id(self):
-        interceptor = google.ads.google_ads.client.MetadataInterceptor(
+        interceptor = Client.MetadataInterceptor(
             self.mock_developer_token,
             None)
 
@@ -415,7 +408,7 @@ class MetadataInterceptorTest(TestCase):
         )
 
     def test_update_client_call_details_metadata(self):
-        interceptor = google.ads.google_ads.client.MetadataInterceptor(
+        interceptor = Client.MetadataInterceptor(
             self.mock_developer_token,
             self.mock_login_customer_id)
 
@@ -428,7 +421,7 @@ class MetadataInterceptorTest(TestCase):
         self.assertEqual(client_call_details.metadata, mock_metadata)
 
     def test_intercept_unary_unary(self):
-        interceptor = google.ads.google_ads.client.MetadataInterceptor(
+        interceptor = Client.MetadataInterceptor(
             self.mock_developer_token,
             self.mock_login_customer_id)
 
@@ -491,7 +484,7 @@ class LoggingInterceptorTest(TestCase):
             config: A dict configuration
             endpoint: A str representing an endpoint
         """
-        return google.ads.google_ads.client.LoggingInterceptor(config, endpoint)
+        return Client.LoggingInterceptor(config, endpoint)
 
     def _get_mock_client_call_details(self):
         """Generates a mock client_call_details object for use in tests.
@@ -576,7 +569,7 @@ class LoggingInterceptorTest(TestCase):
         del exception.request_id
         return exception
 
-    def _get_mock_response(self, failed=False, transport=False):
+    def _get_mock_response(self, failed=False):
         """Generates a mock response object for use in tests.
 
         Accepts a "failed" param that tells the returned mocked response to
@@ -589,8 +582,6 @@ class LoggingInterceptorTest(TestCase):
         Args:
             failed: a bool indicating whether the mock response should be in a
                 failed state or not. Default is False.
-            transport: a bool indicating whether the response should mock a
-                gRPC transport exception.
         """
         def mock_exception_fn():
             if failed:
@@ -629,7 +620,7 @@ class LoggingInterceptorTest(TestCase):
         """Unconfigured LoggingInterceptor should not call logging.dictConfig.
         """
         with mock.patch('logging.config.dictConfig') as mock_dictConfig:
-            google.ads.google_ads.client.LoggingInterceptor()
+            Client.LoggingInterceptor()
             mock_dictConfig.assert_not_called()
 
     def test_init_with_config(self):
@@ -637,7 +628,7 @@ class LoggingInterceptorTest(TestCase):
         """
         config = {'test': True}
         with mock.patch('logging.config.dictConfig') as mock_dictConfig:
-            google.ads.google_ads.client.LoggingInterceptor(config)
+            Client.LoggingInterceptor(config)
             mock_dictConfig.assert_called_once_with(config)
 
     def test_intercept_unary_unary_unconfigured(self):
@@ -652,8 +643,8 @@ class LoggingInterceptorTest(TestCase):
         # Since logging configuration is global it needs to be reset here
         # so that state from previous tests does not affect these assertions
         logging.disable(logging.CRITICAL)
-        logger_spy = mock.Mock(wraps=google.ads.google_ads.client._logger)
-        interceptor = google.ads.google_ads.client.LoggingInterceptor()
+        logger_spy = mock.Mock(wraps=Client._logger)
+        interceptor = Client.LoggingInterceptor()
         interceptor.intercept_unary_unary(
             mock_continuation_fn,
             mock_client_call_details,
@@ -690,12 +681,10 @@ class LoggingInterceptorTest(TestCase):
                     mock_client_call_details.method, self._MOCK_REQUEST_ID,
                     False, None))
 
-            initial_metadata = (google.ads.google_ads.client.
-                                _parse_metadata_to_json(
-                                    mock_client_call_details.metadata))
-            trailing_metadata = (google.ads.google_ads.client.
-                                 _parse_metadata_to_json(
-                                     mock_trailing_metadata))
+            initial_metadata = Client._parse_metadata_to_json(
+                mock_client_call_details.metadata)
+            trailing_metadata = Client._parse_metadata_to_json(
+                mock_trailing_metadata)
 
             mock_logger.debug.assert_called_once_with(
                 interceptor._FULL_REQUEST_LOG_LINE.format(
@@ -728,12 +717,10 @@ class LoggingInterceptorTest(TestCase):
                     mock_client_call_details.method, self._MOCK_REQUEST_ID,
                     True, self._MOCK_ERROR_MESSAGE))
 
-            initial_metadata = (google.ads.google_ads.client.
-                                _parse_metadata_to_json(
-                                    mock_client_call_details.metadata))
-            trailing_metadata = (google.ads.google_ads.client.
-                                 _parse_metadata_to_json(
-                                     mock_trailing_metadata))
+            initial_metadata = Client._parse_metadata_to_json(
+                mock_client_call_details.metadata)
+            trailing_metadata = Client._parse_metadata_to_json(
+                mock_trailing_metadata)
 
             mock_logger.info.assert_called_once_with(
                 interceptor._FULL_FAULT_LOG_LINE.format(
@@ -880,7 +867,7 @@ class ExceptionInterceptorTest(TestCase):
         Returns:
             An ExceptionInterceptor instance.
         """
-        return google.ads.google_ads.client.ExceptionInterceptor()
+        return Client.ExceptionInterceptor()
 
     def test_init_(self):
         """Tests that the interceptor initializes properly"""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -83,7 +83,8 @@ class GoogleAdsClientTest(FileTestCase):
     """Tests for the google.ads.googleads.client.GoogleAdsClient class."""
 
     def _create_test_client(self, endpoint=None):
-        with mock.patch('google.oauth2.credentials') as mock_credentials:
+        with mock.patch(
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_credentials_instance = mock_credentials.return_value
             mock_credentials_instance.refresh_token = self.refresh_token
             mock_credentials_instance.client_id = self.client_id
@@ -116,7 +117,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                 'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
@@ -143,7 +144,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                 'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
@@ -168,7 +169,7 @@ class GoogleAdsClientTest(FileTestCase):
         self.fs.create_file(file_path, contents=yaml.safe_dump(config))
 
         with mock.patch(
-                'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             self.assertRaises(
@@ -189,7 +190,7 @@ class GoogleAdsClientTest(FileTestCase):
         self.fs.create_file(file_path, contents=yaml.safe_dump(config))
 
         with mock.patch(
-                'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             self.assertRaises(
@@ -211,7 +212,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                 'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
@@ -240,7 +241,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
@@ -266,7 +267,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                'google.oauth2.credentials.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.Credentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -789,29 +789,25 @@ class LoggingInterceptorTest(TestCase):
             result = interceptor._get_request_id(mock_response)
             self.assertEqual(result, None)
 
-
-    def test_parse_response_to_json_transport_failure(self):
+    def test_parse_exception_to_str_transport_failure(self):
         """ Calls _parse_to_json with transport error's debug_error_string."""
         with mock.patch('logging.config.dictConfig'), \
             mock.patch(
                 'google.ads.google_ads.client._parse_to_json') as mock_parser:
-            mock_response = mock.Mock()
             mock_exception = self._get_mock_transport_exception()
             interceptor = self._create_test_interceptor()
-            interceptor._parse_response_to_json(mock_response, mock_exception)
+            interceptor._parse_exception_to_str(mock_exception)
             mock_parser.assert_called_once_with(
                 json.loads(self._MOCK_DEBUG_ERROR_STRING))
 
-    def test_parse_response_to_json_unknown_failure(self):
+    def test_parse_exception_to_str_unknown_failure(self):
         """Returns an empty JSON string if nothing can be parsed to JSON."""
         with mock.patch('logging.config.dictConfig'):
-            mock_response = mock.Mock()
             mock_exception = mock.Mock()
             del mock_exception.failure
             del mock_exception.debug_error_string
             interceptor = self._create_test_interceptor()
-            result = interceptor._parse_response_to_json(
-                mock_response, mock_exception)
+            result = interceptor._parse_exception_to_str(mock_exception)
             self.assertEqual(result, '{}')
 
     def test_get_trailing_metadata(self):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -633,22 +633,19 @@ class LoggingInterceptorTest(TestCase):
         mock_client_call_details = self._get_mock_client_call_details()
         mock_continuation_fn = self._get_mock_continuation_fn()
         mock_request = self._get_mock_request()
+        # Since logging configuration is global it needs to be reset here
+        # so that state from previous tests does not affect these assertions
+        logging.disable(logging.CRITICAL)
+        logger_spy = mock.Mock(wraps=google.ads.google_ads.client._logger)
+        interceptor = google.ads.google_ads.client.LoggingInterceptor()
+        interceptor.intercept_unary_unary(
+            mock_continuation_fn,
+            mock_client_call_details,
+            mock_request)
 
-        with mock.patch(
-                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
-            # Since logging configuration is global it needs to be reset here
-            # so that state from previous tests does not affect these assertions
-            logging.disable(logging.CRITICAL)
-            logger_spy = mock.Mock(wraps=google.ads.google_ads.client._logger)
-            interceptor = google.ads.google_ads.client.LoggingInterceptor()
-            interceptor.intercept_unary_unary(
-                mock_continuation_fn,
-                mock_client_call_details,
-                mock_request)
-
-            logger_spy.debug.assert_not_called()
-            logger_spy.info.assert_not_called()
-            logger_spy.warning.assert_not_called()
+        logger_spy.debug.assert_not_called()
+        logger_spy.info.assert_not_called()
+        logger_spy.warning.assert_not_called()
 
     def test_intercept_unary_unary_successful_request(self):
         """_logger.info and _logger.debug should be called.

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -649,16 +649,12 @@ class LoggingInterceptorTest(TestCase):
         mock_client_call_details = self._get_mock_client_call_details()
         mock_continuation_fn = self._get_mock_continuation_fn()
         mock_request = self._get_mock_request()
-        mock_json_message = '{"test": "request-response"}'
         mock_response = mock_continuation_fn(
             mock_client_call_details, mock_request)
         mock_trailing_metadata = mock_response.trailing_metadata()
 
         with mock.patch('logging.config.dictConfig'), \
-            mock.patch('google.ads.google_ads.client._logger') as mock_logger, \
-            mock.patch(
-                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
-            mock_formatter.return_value = mock_json_message
+            mock.patch('google.ads.google_ads.client._logger') as mock_logger:
             interceptor = self._create_test_interceptor()
             interceptor.intercept_unary_unary(
                 mock_continuation_fn,
@@ -681,7 +677,7 @@ class LoggingInterceptorTest(TestCase):
             mock_logger.debug.assert_called_once_with(
                 interceptor._FULL_REQUEST_LOG_LINE
                 % (self._MOCK_METHOD, self._MOCK_ENDPOINT, initial_metadata,
-                    mock_json_message, trailing_metadata, mock_json_message))
+                    mock_request, trailing_metadata, mock_response))
 
     def test_intercept_unary_unary_failed_request(self):
         """_logger.warning and _logger.info should be called.
@@ -790,51 +786,51 @@ class LoggingInterceptorTest(TestCase):
             result = interceptor._get_request_id(mock_response, mock_exception)
             self.assertEqual(result, None)
 
-    def test_parse_response_to_json(self):
-        """Calls MessageToJson with a successful response message."""
-        with mock.patch('logging.config.dictConfig'), \
-            mock.patch(
-                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
-            mock_response = self._get_mock_response()
-            mock_exception = mock_response.exception()
-            interceptor = self._create_test_interceptor()
-            interceptor._parse_response_to_json(mock_response, mock_exception)
-            mock_formatter.assert_called_once_with(mock_response.result())
+#    def test_parse_response_to_json(self):
+#        """Calls MessageToJson with a successful response message."""
+#        with mock.patch('logging.config.dictConfig'), \
+#            mock.patch(
+#                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
+#            mock_response = self._get_mock_response()
+#            mock_exception = mock_response.exception()
+#            interceptor = self._create_test_interceptor()
+#            interceptor._parse_response_to_json(mock_response, mock_exception)
+#            mock_formatter.assert_called_once_with(mock_response.result())
 
-    def test_parse_response_to_json_google_ads_failure(self):
-        """Calls MessageToJson with a GoogleAdsException."""
-        with mock.patch('logging.config.dictConfig'), \
-            mock.patch(
-                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
-            mock_response = mock.Mock()
-            mock_exception = self._get_mock_exception()
-            interceptor = self._create_test_interceptor()
-            interceptor._parse_response_to_json(mock_response, mock_exception)
-            mock_formatter.assert_called_once_with(mock_exception.failure)
+#    def test_parse_response_to_json_google_ads_failure(self):
+#        """Calls MessageToJson with a GoogleAdsException."""
+#        with mock.patch('logging.config.dictConfig'), \
+#            mock.patch(
+#                'google.ads.google_ads.client.MessageToJson') as mock_formatter:
+#            mock_response = mock.Mock()
+#            mock_exception = self._get_mock_exception()
+#            interceptor = self._create_test_interceptor()
+#            interceptor._parse_response_to_json(mock_response, mock_exception)
+#            mock_formatter.assert_called_once_with(mock_exception.failure)
 
-    def test_parse_response_to_json_transport_failure(self):
-        """ Calls _parse_to_json with transport error's debug_error_string."""
-        with mock.patch('logging.config.dictConfig'), \
-            mock.patch(
-                'google.ads.google_ads.client._parse_to_json') as mock_parser:
-            mock_response = mock.Mock()
-            mock_exception = self._get_mock_transport_exception()
-            interceptor = self._create_test_interceptor()
-            interceptor._parse_response_to_json(mock_response, mock_exception)
-            mock_parser.assert_called_once_with(
-                json.loads(self._MOCK_DEBUG_ERROR_STRING))
+#    def test_parse_response_to_json_transport_failure(self):
+#        """ Calls _parse_to_json with transport error's debug_error_string."""
+#        with mock.patch('logging.config.dictConfig'), \
+#            mock.patch(
+#                'google.ads.google_ads.client._parse_to_json') as mock_parser:
+#            mock_response = mock.Mock()
+#            mock_exception = self._get_mock_transport_exception()
+#            interceptor = self._create_test_interceptor()
+#            interceptor._parse_response_to_json(mock_response, mock_exception)
+#            mock_parser.assert_called_once_with(
+#                json.loads(self._MOCK_DEBUG_ERROR_STRING))
 
-    def test_parse_response_to_json_unknown_failure(self):
-        """Returns an empty JSON string if nothing can be parsed to JSON."""
-        with mock.patch('logging.config.dictConfig'):
-            mock_response = mock.Mock()
-            mock_exception = mock.Mock()
-            del mock_exception.failure
-            del mock_exception.debug_error_string
-            interceptor = self._create_test_interceptor()
-            result = interceptor._parse_response_to_json(
-                mock_response, mock_exception)
-            self.assertEqual(result, '{}')
+#    def test_parse_response_to_json_unknown_failure(self):
+#        """Returns an empty JSON string if nothing can be parsed to JSON."""
+#        with mock.patch('logging.config.dictConfig'):
+#            mock_response = mock.Mock()
+#            mock_exception = mock.Mock()
+#            del mock_exception.failure
+#            del mock_exception.debug_error_string
+#            interceptor = self._create_test_interceptor()
+#            result = interceptor._parse_response_to_json(
+#                mock_response, mock_exception)
+#            self.assertEqual(result, '{}')
 
     def test_get_trailing_metadata(self):
         """Retrieves metadata from a response object."""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -453,6 +453,7 @@ class LoggingInterceptorTest(TestCase):
     _MOCK_REQUEST_ID = '654321xyz'
     _MOCK_METHOD = 'test/method'
     _MOCK_TRAILING_METADATA = (('request-id', _MOCK_REQUEST_ID),)
+    _MOCK_TRANSPORT_ERROR_METADATA = tuple()
     _MOCK_ERROR_MESSAGE = 'Test error message'
     _MOCK_TRANSPORT_ERROR_MESSAGE = u'Received RST_STREAM with error code 2'
     _MOCK_DEBUG_ERROR_STRING = u'{"description":"Error received from peer"}'
@@ -546,7 +547,7 @@ class LoggingInterceptorTest(TestCase):
             return self._MOCK_TRANSPORT_ERROR_MESSAGE
 
         def _mock_trailing_metadata():
-            return self._MOCK_TRAILING_METADATA
+            return self._MOCK_TRANSPORT_ERROR_METADATA
 
         exception = mock.Mock()
         exception.debug_error_string = _mock_debug_error_string
@@ -740,7 +741,7 @@ class LoggingInterceptorTest(TestCase):
             mock_client_call_details = {}
             interceptor = self._create_test_interceptor()
             result = interceptor._get_initial_metadata(mock_client_call_details)
-            self.assertEqual(result, tuple())
+            self.assertEqual(result, self._MOCK_TRANSPORT_ERROR_METADATA)
 
     def test_get_call_method(self):
         """Returns a str of the call method from client_call_details"""
@@ -782,6 +783,7 @@ class LoggingInterceptorTest(TestCase):
                 return self._get_mock_transport_exception()
 
             mock_response = self._get_mock_response(failed=True)
+            del mock_response.trailing_metadata
             mock_response.exception = mock_transport_exception
             # exceptions on transport errors have no request_id because they
             # don't interact with a server that can provide one.
@@ -837,7 +839,7 @@ class LoggingInterceptorTest(TestCase):
             mock_response.exception = mock_transport_exception
             interceptor = self._create_test_interceptor()
             result = interceptor._get_trailing_metadata(mock_response)
-            self.assertEqual(result, self._MOCK_TRAILING_METADATA)
+            self.assertEqual(result, tuple())
 
     def test_get_trailing_metadata_unknown_failure(self):
         """Returns an empty tuple if metadata cannot be found."""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -669,8 +669,8 @@ class LoggingInterceptorTest(TestCase):
                 mock_request)
 
             mock_logger.info.assert_called_once_with(
-                interceptor._SUMMARY_LOG_LINE
-                % (self._MOCK_CUSTOMER_ID, self._MOCK_ENDPOINT,
+                interceptor._SUMMARY_LOG_LINE.format(
+                    self._MOCK_CUSTOMER_ID, self._MOCK_ENDPOINT,
                     mock_client_call_details.method, self._MOCK_REQUEST_ID,
                     False, None))
 
@@ -682,8 +682,8 @@ class LoggingInterceptorTest(TestCase):
                                      mock_trailing_metadata))
 
             mock_logger.debug.assert_called_once_with(
-                interceptor._FULL_REQUEST_LOG_LINE
-                % (self._MOCK_METHOD, self._MOCK_ENDPOINT, initial_metadata,
+                interceptor._FULL_REQUEST_LOG_LINE.format(
+                    self._MOCK_METHOD, self._MOCK_ENDPOINT, initial_metadata,
                     mock_request, trailing_metadata, mock_response.result()))
 
     def test_intercept_unary_unary_failed_request(self):
@@ -707,8 +707,8 @@ class LoggingInterceptorTest(TestCase):
             mock_trailing_metadata = mock_response.trailing_metadata()
 
             mock_logger.warning.assert_called_once_with(
-                interceptor._SUMMARY_LOG_LINE
-                % (self._MOCK_CUSTOMER_ID, self._MOCK_ENDPOINT,
+                interceptor._SUMMARY_LOG_LINE.format(
+                    self._MOCK_CUSTOMER_ID, self._MOCK_ENDPOINT,
                     mock_client_call_details.method, self._MOCK_REQUEST_ID,
                     True, self._MOCK_ERROR_MESSAGE))
 
@@ -720,8 +720,8 @@ class LoggingInterceptorTest(TestCase):
                                      mock_trailing_metadata))
 
             mock_logger.info.assert_called_once_with(
-                interceptor._FULL_FAULT_LOG_LINE
-                % (self._MOCK_METHOD, self._MOCK_ENDPOINT, initial_metadata,
+                interceptor._FULL_FAULT_LOG_LINE.format(
+                    self._MOCK_METHOD, self._MOCK_ENDPOINT, initial_metadata,
                     mock_request, trailing_metadata,
                     mock_response.exception().failure))
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -790,10 +790,11 @@ class LoggingInterceptorTest(TestCase):
             self.assertEqual(result, None)
 
     def test_parse_exception_to_str_transport_failure(self):
-        """ Calls _parse_to_json with transport error's debug_error_string."""
+        """ Calls _format_json_object with error obj's debug_error_string."""
         with mock.patch('logging.config.dictConfig'), \
             mock.patch(
-                'google.ads.google_ads.client._parse_to_json') as mock_parser:
+                'google.ads.google_ads.client._format_json_object'
+                ) as mock_parser:
             mock_exception = self._get_mock_transport_exception()
             interceptor = self._create_test_interceptor()
             interceptor._parse_exception_to_str(mock_exception)


### PR DESCRIPTION
JSON Serialization of fields such as `video_quartile_25_rate` that contain a digit following an underscore will raise errors in Python.

This is expected behavior because it's not possible to serialize from snake_case to camelCase and back when a digit follows an underscore.

The fields in the API that contain this pattern are technically breaking this convention, but until a broader resolution is arrived at it's easier for now to simply not serialize messages to JSON for the purposes of logging because proto objects serialize to string very well on their own already.

This PR also introduces some general refactoring and cleanup.