### PR TITLE
Update service-level timeout and method-level idempotency configuration.

### DIFF
--- a/google/ads/google_ads/v1/services/account_budget_proposal_service_client_config.py
+++ b/google/ads/google_ads/v1/services/account_budget_proposal_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/account_budget_service_client_config.py
+++ b/google/ads/google_ads/v1/services/account_budget_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_ad_label_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_ad_label_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_ad_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_ad_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_audience_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_audience_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_bid_modifier_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_bid_modifier_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_criterion_label_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_criterion_label_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_criterion_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_criterion_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_criterion_simulation_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_criterion_simulation_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_extension_setting_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_extension_setting_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_feed_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_feed_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_label_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_label_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_group_simulation_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_group_simulation_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_parameter_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_parameter_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/ad_schedule_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/ad_schedule_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/age_range_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/age_range_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/asset_service_client_config.py
+++ b/google/ads/google_ads/v1/services/asset_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/bidding_strategy_service_client_config.py
+++ b/google/ads/google_ads/v1/services/bidding_strategy_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/billing_setup_service_client_config.py
+++ b/google/ads/google_ads/v1/services/billing_setup_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_audience_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_audience_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_bid_modifier_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_bid_modifier_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_budget_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_budget_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_criterion_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_criterion_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_criterion_simulation_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_criterion_simulation_service_client_config.py
@@ -8,13 +8,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_draft_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_draft_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_experiment_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_experiment_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_extension_setting_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_extension_setting_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_feed_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_feed_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_label_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_label_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/campaign_shared_set_service_client_config.py
+++ b/google/ads/google_ads/v1/services/campaign_shared_set_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/carrier_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/carrier_constant_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/change_status_service_client_config.py
+++ b/google/ads/google_ads/v1/services/change_status_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/click_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/click_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/conversion_action_service_client_config.py
+++ b/google/ads/google_ads/v1/services/conversion_action_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/conversion_adjustment_upload_service_client_config.py
+++ b/google/ads/google_ads/v1/services/conversion_adjustment_upload_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/conversion_upload_service_client_config.py
+++ b/google/ads/google_ads/v1/services/conversion_upload_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/custom_interest_service_client_config.py
+++ b/google/ads/google_ads/v1/services/custom_interest_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_client_link_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_client_link_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_client_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_client_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_extension_setting_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_extension_setting_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_feed_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_feed_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_label_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_label_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_manager_link_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_manager_link_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_negative_criterion_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_negative_criterion_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/customer_service_client_config.py
+++ b/google/ads/google_ads/v1/services/customer_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/detail_placement_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/detail_placement_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/display_keyword_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/display_keyword_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/domain_category_service_client_config.py
+++ b/google/ads/google_ads/v1/services/domain_category_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/dynamic_search_ads_search_term_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/dynamic_search_ads_search_term_view_service_client_config.py
@@ -8,13 +8,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/expanded_landing_page_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/expanded_landing_page_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/extension_feed_item_service_client_config.py
+++ b/google/ads/google_ads/v1/services/extension_feed_item_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/feed_item_service_client_config.py
+++ b/google/ads/google_ads/v1/services/feed_item_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/feed_item_target_service_client_config.py
+++ b/google/ads/google_ads/v1/services/feed_item_target_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/feed_mapping_service_client_config.py
+++ b/google/ads/google_ads/v1/services/feed_mapping_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/feed_placeholder_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/feed_placeholder_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/feed_service_client_config.py
+++ b/google/ads/google_ads/v1/services/feed_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/gender_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/gender_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/geo_target_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/geo_target_constant_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/geographic_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/geographic_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/google_ads_field_service_client_config.py
+++ b/google/ads/google_ads/v1/services/google_ads_field_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {
@@ -24,7 +24,7 @@ config = {
                 },
                 "SearchGoogleAdsFields": {
                     "timeout_millis": 600000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default"
                 }
             }

--- a/google/ads/google_ads/v1/services/google_ads_service_client_config.py
+++ b/google/ads/google_ads/v1/services/google_ads_service_client_config.py
@@ -7,19 +7,19 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {
                 "Search": {
                     "timeout_millis": 3600000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default"
                 },
                 "Mutate": {

--- a/google/ads/google_ads/v1/services/group_placement_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/group_placement_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/hotel_group_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/hotel_group_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/hotel_performance_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/hotel_performance_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/keyword_plan_ad_group_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_plan_ad_group_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/keyword_plan_campaign_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_plan_campaign_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/keyword_plan_idea_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_plan_idea_service_client_config.py
@@ -7,19 +7,19 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {
                 "GenerateKeywordIdeas": {
                     "timeout_millis": 600000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default"
                 }
             }

--- a/google/ads/google_ads/v1/services/keyword_plan_keyword_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_plan_keyword_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/keyword_plan_negative_keyword_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_plan_negative_keyword_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/keyword_plan_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_plan_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {
@@ -29,12 +29,12 @@ config = {
                 },
                 "GenerateForecastMetrics": {
                     "timeout_millis": 600000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default"
                 },
                 "GenerateHistoricalMetrics": {
                     "timeout_millis": 600000,
-                    "retry_codes_name": "non_idempotent",
+                    "retry_codes_name": "idempotent",
                     "retry_params_name": "default"
                 }
             }

--- a/google/ads/google_ads/v1/services/keyword_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/keyword_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/label_service_client_config.py
+++ b/google/ads/google_ads/v1/services/label_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/landing_page_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/landing_page_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/language_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/language_constant_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/location_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/location_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/managed_placement_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/managed_placement_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/media_file_service_client_config.py
+++ b/google/ads/google_ads/v1/services/media_file_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/merchant_center_link_service_client_config.py
+++ b/google/ads/google_ads/v1/services/merchant_center_link_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/mobile_app_category_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/mobile_app_category_constant_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/mobile_device_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/mobile_device_constant_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/mutate_job_service_client_config.py
+++ b/google/ads/google_ads/v1/services/mutate_job_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/operating_system_version_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/operating_system_version_constant_service_client_config.py
@@ -8,13 +8,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/paid_organic_search_term_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/paid_organic_search_term_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/parental_status_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/parental_status_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/payments_account_service_client_config.py
+++ b/google/ads/google_ads/v1/services/payments_account_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/product_bidding_category_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/product_bidding_category_constant_service_client_config.py
@@ -8,13 +8,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/product_group_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/product_group_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/recommendation_service_client_config.py
+++ b/google/ads/google_ads/v1/services/recommendation_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/remarketing_action_service_client_config.py
+++ b/google/ads/google_ads/v1/services/remarketing_action_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/search_term_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/search_term_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/shared_criterion_service_client_config.py
+++ b/google/ads/google_ads/v1/services/shared_criterion_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/shared_set_service_client_config.py
+++ b/google/ads/google_ads/v1/services/shared_set_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/shopping_performance_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/shopping_performance_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/topic_constant_service_client_config.py
+++ b/google/ads/google_ads/v1/services/topic_constant_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/topic_view_service_client_config.py
+++ b/google/ads/google_ads/v1/services/topic_view_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/user_interest_service_client_config.py
+++ b/google/ads/google_ads/v1/services/user_interest_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/user_list_service_client_config.py
+++ b/google/ads/google_ads/v1/services/user_list_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {

--- a/google/ads/google_ads/v1/services/video_service_client_config.py
+++ b/google/ads/google_ads/v1/services/video_service_client_config.py
@@ -7,13 +7,13 @@ config = {
             },
             "retry_params": {
                 "default": {
-                    "initial_retry_delay_millis": 100,
+                    "initial_retry_delay_millis": 5000,
                     "retry_delay_multiplier": 1.3,
                     "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                    "initial_rpc_timeout_millis": 3600000,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 3600000,
+                    "total_timeout_millis": 3600000
                 }
             },
             "methods": {


### PR DESCRIPTION
This change updates our client-side timeout settings to more closely match those that are defined by the server in order to prevent the client library from ending requests too soon and ultimately reducing the amount of DEADLINE_EXCEEDED errors that are generated.

Before this change _all_ services were configured with a *20* second timeout in the client library. The majority of services have a _server-side_ timeout of *60* seconds, and in the case of `GoogleAdsService.Search` there's a 1 hour server-side timeout. This change sets the client-side timeouts to the upper bound (1 hour) in order to prevent the client library from ending requests prematurely.

Additionally a few service methods (including `GoogleAdsService.Search`) were previously incorrectly configured to be `non_idempotent`. This means that such methods would not retry requests at all, causing a behavior where a search request would wait 20 seconds for a response and fail instead of retrying. With the change search requests (and a few others) will properly retry if they encounter a DEADLINE_EXCEEDED or UNAVAILABLE error from the server.