### PR TITLE
Add Service account support and refactor credentials and oauth logic.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,16 @@ is a `template`_ you can use.
 For a complete walk-through of the OAuth Installed Application flow in Python, 
 please refer to `this page of the wiki`_.
 
+OAuth2 Options
+##############
+
+This client library can authenticate using one of two different OAuth2 flows, either the
+`Installed Application Flow`_ or the `Service Account Flow`_. When retrieving the configuration
+for these authentication flows, if configuration is present for _both_ flows the library will
+default to using the Installed Application Flow. If you wish to use the Service Account Flow
+you must make sure that the Installed Application Flow configuration values are not present
+in your configuration.
+
 Create a GoogleAdsClient
 ########################
 
@@ -69,10 +79,20 @@ You can also retrieve it exporting environment variables.
 
 .. code-block:: bash
 
+  export GOOGLE_ADS_DEVELOPER_TOKEN=INSERT_DEVELOPER_TOKEN_HERE
+
+* Required for OAuth2 Installed Application Flow
+
+.. code-block::bash
+
   export GOOGLE_ADS_CLIENT_ID=INSERT_OAUTH2_CLIENT_ID_HERE
   export GOOGLE_ADS_CLIENT_SECRET=INSERT_OAUTH2_CLIENT_SECRET_HERE
   export GOOGLE_ADS_REFRESH_TOKEN=INSERT_REFRESH_TOKEN_HERE
-  export GOOGLE_ADS_DEVELOPER_TOKEN=INSERT_DEVELOPER_TOKEN_HERE
+
+* Required for OAuth2 Service Account Flow:
+
+  export GOOGLE_ADS_PATH_TO_PRIVATE_KEY_FILE=INSERT_PRIVATE_KEY_PATH_HERE
+  export GOOGLE_ADS_DELEGATED_ACCOUNT=INSERT_DELEGATED_ACCOUNT_HERE
 
 * Optional:
 
@@ -192,6 +212,8 @@ Authors
 * `David Wihl`_
 * `Ben Karl`_
 
+.. _Installed Application Flow: https://developers.google.com/google-ads/api/docs/client-libs/dotnet/oauth-installed
+.. _Service Account Flow: https://developers.google.com/google-ads/api/docs/client-libs/dotnet/oauth-service
 .. _pip: https://pip.pypa.io/en/stable/installing
 .. _blog post: https://ads-developers.googleblog.com/2019/04/python-2-deprecation-in-ads-api-client.html
 .. _template: https://github.com/googleads/google-ads-python/blob/master/google-ads.yaml

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ Requirements
 * `pip`_
 
 
+Documentation
+-------------
+This README has general information to get you started with the library, but more
+extensive documentation can be found on our `Developer Site`_.
+
 Getting started
 ---------------
 
@@ -33,8 +38,12 @@ Configuration file setup
 ########################
 
 To authenticate your API calls, you must specify your **client ID**,
-**client secret**, **refresh token**, **developer token**, and, if
-you are authenticating with a manager account, a **login customer id**.
+**client secret**, **refresh token**, **developer token**, or, if you
+are authenticating via a service account you will instead need to specify
+a **path_to_private_key_file** and **delegate_account**. If you
+are authenticating with a manager account you will need to provide a
+**login customer id** configuration value.
+
 If you have not yet created a client ID, see the `Authorization guide`_
 and the `authentication samples`_ to get started. Likewise, see
 `Obtain your developer token`_ if you do not yet have one.
@@ -44,18 +53,20 @@ class method, the default behavior is to load a configuration file named
 **google-ads.yaml** located in your home directory. Included in this repository
 is a `template`_ you can use.
 
-For a complete walk-through of the OAuth Installed Application flow in Python,
-please refer to `this page of the wiki`_.
+For a complete walk-through of how to configure this library, please refer
+to our `configuration documentation`_.
 
 OAuth2 Options
 ##############
 
-This client library can authenticate using one of two different OAuth2 flows, either the
-`Installed Application Flow`_ or the `Service Account Flow`_. When retrieving the configuration
-for these authentication flows, if configuration is present for _both_ flows the library will
-default to using the Installed Application Flow. If you wish to use the Service Account Flow
-you must make sure that the Installed Application Flow `configuration values`_ are not present
-in your configuration.
+This client library can authenticate using one of three different OAuth2 flows, either the
+`Installed Application Flow`_, the `Web Application Flow`_ or the `Service Account Flow`_.
+The Installed Application Flow and Web Application Flow use the same credentials and are
+functionally identical in terms of configuring this library. When retrieving the
+configuration for these authentication flows, if configuration is present
+for _both_ types of flows the library will default to using the Installed/Web Application
+Flow. If you wish to use the Service Account Flow you must make sure that the Installed/Web
+Application Flow `configuration values`_ are not present in your configuration.
 
 Create a GoogleAdsClient
 ########################
@@ -68,12 +79,13 @@ configuration file named **google-ads.yaml** stored in your home directory:
 
 .. code-block:: python
 
-  client = google.ads.google_ads.client.GoogleAdsClient.load_from_storage()
+  from google.ads.google_ads.client import GoogleAdsClient
+  client = GoogleAdsClient.load_from_storage()
 
 Using environment variables
 ***************************
 
-You can also retrieve it exporting environment variables.
+You can also retrieve it by exporting environment variables.
 
 * Required:
 
@@ -114,8 +126,11 @@ Then run the following to retrieve a GoogleAdsClient instance:
 
 .. code-block:: python
 
-  client = google.ads.google_ads.client.GoogleAdsClient.load_from_env()
+  from google.ads.google_ads.client import GoogleAdsClient
+  client = GoogleAdsClient.load_from_env()
 
+The `configuration documentation`_ has more information on how these different
+sets of variables are set and retrieved.
 
 Get types and service clients
 #############################
@@ -133,6 +148,8 @@ retrieve the corresponding service client instance:
 .. code-block:: python
 
   google_ads_service = client.get_service('GoogleAdsService')
+
+More details can be found in our `proto getters documentation`_.
 
 API versioning
 ################################
@@ -212,14 +229,17 @@ Authors
 * `David Wihl`_
 * `Ben Karl`_
 
-.. _Installed Application Flow: https://developers.google.com/google-ads/api/docs/client-libs/dotnet/oauth-installed
-.. _Service Account Flow: https://developers.google.com/google-ads/api/docs/client-libs/dotnet/oauth-service
+.. _Developer Site: https://developers.google.com/google-ads/api/docs/client-libs/python/
+.. _Installed Application Flow: https://developers.google.com/google-ads/api/docs/client-libs/python/oauth-installed
+.. _Web Application Flow: https://developers.google.com/google-ads/api/docs/client-libs/python/oauth-web
+.. _Service Account Flow: https://developers.google.com/google-ads/api/docs/client-libs/python/oauth-service
 .. _configuration values: https://github.com/googleads/google-ads-python/blob/master/google-ads.yaml#L1
 .. _pip: https://pip.pypa.io/en/stable/installing
 .. _blog post: https://ads-developers.googleblog.com/2019/04/python-2-deprecation-in-ads-api-client.html
 .. _template: https://github.com/googleads/google-ads-python/blob/master/google-ads.yaml
-.. _this page of the wiki: https://github.com/googleads/google-ads-python/wiki/OAuth-Installed-Application-Flow
+.. _configuration documentation: https://developers.google.com/google-ads/api/docs/client-libs/python/configuration
 .. _Authorization guide: https://developers.google.com/google-ads/api/docs/oauth/overview
+.. _proto getters documentation: https://developers.google.com/google-ads/api/docs/client-libs/python/proto-getters
 .. _authentication samples: https://github.com/googleads/google-ads-python/blob/master/examples/authentication
 .. _Obtain your developer token: https://developers.google.com/google-ads/api/docs/first-call/dev-token
 .. _google-ads.yaml: https://github.com/googleads/google-ads-python/blob/master/google-ads.yaml

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ class method, the default behavior is to load a configuration file named
 **google-ads.yaml** located in your home directory. Included in this repository
 is a `template`_ you can use.
 
-For a complete walk-through of the OAuth Installed Application flow in Python, 
+For a complete walk-through of the OAuth Installed Application flow in Python,
 please refer to `this page of the wiki`_.
 
 OAuth2 Options
@@ -54,7 +54,7 @@ This client library can authenticate using one of two different OAuth2 flows, ei
 `Installed Application Flow`_ or the `Service Account Flow`_. When retrieving the configuration
 for these authentication flows, if configuration is present for _both_ flows the library will
 default to using the Installed Application Flow. If you wish to use the Service Account Flow
-you must make sure that the Installed Application Flow configuration values are not present
+you must make sure that the Installed Application Flow `configuration values`_ are not present
 in your configuration.
 
 Create a GoogleAdsClient
@@ -214,6 +214,7 @@ Authors
 
 .. _Installed Application Flow: https://developers.google.com/google-ads/api/docs/client-libs/dotnet/oauth-installed
 .. _Service Account Flow: https://developers.google.com/google-ads/api/docs/client-libs/dotnet/oauth-service
+.. _configuration values: https://github.com/googleads/google-ads-python/blob/master/google-ads.yaml#L1
 .. _pip: https://pip.pypa.io/en/stable/installing
 .. _blog post: https://ads-developers.googleblog.com/2019/04/python-2-deprecation-in-ads-api-client.html
 .. _template: https://github.com/googleads/google-ads-python/blob/master/google-ads.yaml

--- a/google-ads.yaml
+++ b/google-ads.yaml
@@ -1,13 +1,36 @@
+-# OAuth2 configuration
+-###############################################################################
+-# The below configuration parameters are used to authenticate using the       #
+-# recommended OAuth2 flow. For more information on authenticating with OAuth2 #
+-# see: https://developers.google.com/google-ads/api/docs/oauth/overview       #
+-###############################################################################
 developer_token: INSERT_DEVELOPER_TOKEN_HERE
 client_id: INSERT_OAUTH2_CLIENT_ID_HERE
 client_secret: INSERT_OAUTH2_CLIENT_SECRET_HERE
 refresh_token: INSERT_REFRESH_TOKEN_HERE
-# Required for manager accounts only: Specify the login customer ID used to
-# authenticate API calls. This will be the customer ID of the authenticated
-# manager account. It should be set without dashes, for example: 1234567890
-# instead of 123-456-7890. You can also specify this later in code if your
-# application uses multiple manager account + OAuth pairs.
+
+-# Login customer ID configuration
+-###############################################################################
+-# Required for manager accounts only: Specify the login customer ID used to   #
+-# authenticate API calls. This will be the customer ID of the authenticated   #
+-# manager account. It should be set without dashes, for example: 1234567890   #
+-# instead of 123-456-7890. You can also specify this later in code if your    #
+-# application uses multiple manager account + OAuth pairs.                    #
+-###############################################################################
 login_customer_id: INSERT_LOGIN_CUSTOMER_ID_HERE
+
+-# Service Account configuration
+-###############################################################################
+-# To authenticate with a service account add the appropriate values to the    #
+-# below configuration parameters and remove the four OAuth credentials above. #
+-# The "path_to_private_key_file" value should be a path to your local private #
+-# key json file, and "delegated_account" should be the email address that is  #
+-# being used to impersonate the credentials making requests. for more         #
+-# information on service accounts, see:                                       #
+-# https://developers.google.com/google-ads/api/docs/oauth/service-accounts    #
+-###############################################################################
+-# path_to_private_key_file: INSERT_PATH_TO_JSON_KEY_FILE_HERE
+-# delegated_account: INSERT_DOMAIN_WIDE_DELEGATION_ACCOUNT
 
 # Logging configuration
 ###############################################################################

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -32,10 +32,6 @@ from google.ads.google_ads.errors import GoogleAdsException
 
 _logger = logging.getLogger(__name__)
 
-_REQUIRED_KEYS = ('developer_token',)
-_OPTIONAL_KEYS = ('login_customer_id', 'endpoint', 'logging')
-_OAUTH2_INSTALLED_APP_KEYS = ('client_id', 'client_secret', 'refresh_token')
-_OAUTH2_SERVICE_ACCOUNT_KEYS = ('path_to_private_key_file', 'delegated_account')
 _SERVICE_ACCOUNT_SCOPES = ['https://www.googleapis.com/auth/adwords']
 _SERVICE_CLIENT_TEMPLATE = '%sClient'
 _SERVICE_GRPC_TRANSPORT_TEMPLATE = '%sGrpcTransport'
@@ -44,14 +40,6 @@ _DEFAULT_TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
 _VALID_API_VERSIONS = ['v1']
 _DEFAULT_VERSION = _VALID_API_VERSIONS[0]
 _REQUEST_ID_KEY = 'request-id'
-_ENV_PREFIX = 'GOOGLE_ADS_'
-_KEYS_ENV_VARIABLES_MAP = {
-    key: _ENV_PREFIX + key.upper() for key in
-    list(_REQUIRED_KEYS) +
-    list(_OPTIONAL_KEYS) +
-    list(_OAUTH2_INSTALLED_APP_KEYS) +
-    list(_OAUTH2_SERVICE_ACCOUNT_KEYS)
-}
 
 class GoogleAdsClient(object):
     """Google Ads client used to configure settings and fetch services."""
@@ -73,10 +61,10 @@ class GoogleAdsClient(object):
         Raises:
             ValueError: If the configuration lacks a required field.
         """
-        if not all(key in config_data for key in _REQUIRED_KEYS):
+        if not all(key in config_data for key in config._REQUIRED_KEYS):
             raise ValueError(error_message)
 
-        if all(key in config_data for key in _OAUTH2_INSTALLED_APP_KEYS):
+        if all(key in config_data for key in config._OAUTH2_INSTALLED_APP_KEYS):
             # Using the Installed App Flow
             credentials = InstalledAppCredentials(
                 None,
@@ -84,7 +72,7 @@ class GoogleAdsClient(object):
                 client_id=config_data.get('client_id'),
                 client_secret=config_data.get('client_secret'),
                 token_uri=_DEFAULT_TOKEN_URI)
-        elif all(key in config_data for key in _OAUTH2_SERVICE_ACCOUNT_KEYS):
+        elif all(key in config_data for key in config._OAUTH2_SERVICE_ACCOUNT_KEYS):
             # Using the Service Account Flow
             credentials = ServiceAccountCreds.from_service_account_file(
                 config_data.get('path_to_private_key_file'),
@@ -95,8 +83,8 @@ class GoogleAdsClient(object):
                              'OAuth2. You need to specify credentials for '
                              'either the OAuth2 installed application flow '
                              '({}) or service account flow ({}).'.format(
-                                _OAUTH2_INSTALLED_APP_KEYS,
-                                _OAUTH2_SERVICE_ACCOUNT_KEYS))
+                                config._OAUTH2_INSTALLED_APP_KEYS,
+                                config._OAUTH2_SERVICE_ACCOUNT_KEYS))
 
         credentials.refresh(Request())
 
@@ -125,7 +113,7 @@ class GoogleAdsClient(object):
         """
         config_data = {
             key: os.environ[env_variable]
-            for key, env_variable in _KEYS_ENV_VARIABLES_MAP.items()
+            for key, env_variable in config._KEYS_ENV_VARIABLES_MAP.items()
             if env_variable in os.environ
         }
         if 'logging' in config_data.keys():
@@ -141,8 +129,8 @@ class GoogleAdsClient(object):
             'required environment variables are: %s'
             % str(
                 tuple(
-                    v for k, v in _KEYS_ENV_VARIABLES_MAP.items()
-                    if k in _REQUIRED_KEYS
+                    v for k, v in config._KEYS_ENV_VARIABLES_MAP.items()
+                    if k in config._REQUIRED_KEYS
                 )
             )
         )
@@ -179,7 +167,7 @@ class GoogleAdsClient(object):
         kwargs = cls._get_client_kwargs(
             config_data,
             'A required field in the configuration data was not found. The '
-            'required fields are: {}'.format(str(_REQUIRED_KEYS)))
+            'required fields are: {}'.format(str(config._REQUIRED_KEYS)))
 
         return cls(**kwargs)
 
@@ -204,7 +192,7 @@ class GoogleAdsClient(object):
         kwargs = cls._get_client_kwargs(
             config_data,
             'A required field in the configuration data was not found. The '
-            'required fields are: {}'.format(str(_REQUIRED_KEYS)))
+            'required fields are: {}'.format(str(config._REQUIRED_KEYS)))
 
         return cls(**kwargs)
 

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -20,8 +20,6 @@ import grpc
 from collections import namedtuple
 from importlib import import_module
 
-from google.auth.transport.requests import Request
-from google.oauth2.service_account import Credentials as ServiceAccountCreds
 from google.protobuf.message import DecodeError
 
 from google.ads.google_ads import config
@@ -30,7 +28,6 @@ from google.ads.google_ads.errors import GoogleAdsException
 
 _logger = logging.getLogger(__name__)
 
-_SERVICE_ACCOUNT_SCOPES = ['https://www.googleapis.com/auth/adwords']
 _SERVICE_CLIENT_TEMPLATE = '%sClient'
 _SERVICE_GRPC_TRANSPORT_TEMPLATE = '%sGrpcTransport'
 _PROTO_TEMPLATE = '%s_pb2'
@@ -66,11 +63,9 @@ class GoogleAdsClient(object):
                 _DEFAULT_TOKEN_URI)
         elif all(key in config_data for key in config._OAUTH2_SERVICE_ACCOUNT_KEYS):
             # Using the Service Account Flow
-            credentials = ServiceAccountCreds.from_service_account_file(
+            credentials = oauth2.get_service_account_credentials(
                 config_data.get('path_to_private_key_file'),
-                scopes = _SERVICE_ACCOUNT_SCOPES,
-                subject = config_data.get('delegated_account'))
-            credentials.refresh(Request())
+                config_data.get('delegated_account'))
         else:
             raise ValueError('Your yaml file is incorrectly configured for '
                              'OAuth2. You need to specify credentials for '

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -31,7 +31,6 @@ _logger = logging.getLogger(__name__)
 _SERVICE_CLIENT_TEMPLATE = '%sClient'
 _SERVICE_GRPC_TRANSPORT_TEMPLATE = '%sGrpcTransport'
 _PROTO_TEMPLATE = '%s_pb2'
-_DEFAULT_TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
 _VALID_API_VERSIONS = ['v1']
 _DEFAULT_VERSION = _VALID_API_VERSIONS[0]
 _REQUEST_ID_KEY = 'request-id'
@@ -59,8 +58,7 @@ class GoogleAdsClient(object):
             credentials = oauth2.get_installed_app_credentials(
                 config_data.get('client_id'),
                 config_data.get('client_secret'),
-                config_data.get('refresh_token'),
-                _DEFAULT_TOKEN_URI)
+                config_data.get('refresh_token'))
         elif all(key in config_data for key in config._OAUTH2_SERVICE_ACCOUNT_KEYS):
             # Using the Service Account Flow
             credentials = oauth2.get_service_account_credentials(

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -98,31 +98,6 @@ class GoogleAdsClient(object):
                 'logging_config': config_data.get('logging')}
 
     @classmethod
-    def _get_client_kwargs_from_env(cls):
-        """Utility function used to load client kwargs from env variables.
-
-        Returns:
-            A dict containing configuration data that will be provided to the
-            GoogleAdsClient initializer as keyword arguments.
-
-        Raises:
-            ValueError: If the environment lacks a required field or
-                GOOGLE_ADS_LOGGING env variable is not in JSON format.
-        """
-        config_data = config.load_from_env()
-        return cls._get_client_kwargs(
-            config_data,
-            'A required variable was not found in the environment. The '
-            'required environment variables are: %s'
-            % str(
-                tuple(
-                    v for k, v in config._KEYS_ENV_VARIABLES_MAP.items()
-                    if k in config._REQUIRED_KEYS
-                )
-            )
-        )
-
-    @classmethod
     def load_from_env(cls):
         """Creates a GoogleAdsClient with data stored in the env variables.
 
@@ -133,8 +108,15 @@ class GoogleAdsClient(object):
         Raises:
             ValueError: If the configuration lacks a required field.
         """
-
-        return cls(**cls._get_client_kwargs_from_env())
+        config_data = config.load_from_env()
+        return cls(cls._get_client_kwargs(
+            config_data,
+            'A required variable was not found in the environment. The '
+            'required environment variables are: %s'
+            % str(
+                tuple(
+                    v for k, v in config._KEYS_ENV_VARIABLES_MAP.items()
+                    if k in config._REQUIRED_KEYS))))
 
     @classmethod
     def load_from_string(cls, yaml_str):
@@ -152,11 +134,7 @@ class GoogleAdsClient(object):
             ValueError: If the configuration lacks a required field.
         """
         config_data = config.parse_yaml_document_to_dict(yaml_str)
-        kwargs = cls._get_client_kwargs(
-            config_data,
-            'A required field in the configuration data was not found. The '
-            'required fields are: {}'.format(str(config._REQUIRED_KEYS)))
-
+        kwargs = cls._get_client_kwargs(config_data)
         return cls(**kwargs)
 
     @classmethod
@@ -220,8 +198,6 @@ class GoogleAdsClient(object):
             login_customer_id: a str specifying a login customer ID.
             logging_config: a dict specifying logging config options.
         """
-        _validate_login_customer_id(login_customer_id)
-
         self.credentials = credentials
         self.developer_token = developer_token
         self.endpoint = endpoint
@@ -706,23 +682,6 @@ def _get_version(name):
                          'exist. Valid API versions are: "%s"' %
                                  (name, '", "'.join(_VALID_API_VERSIONS)))
     return version
-
-
-def _validate_login_customer_id(login_customer_id):
-    """Validates a login customer ID.
-
-    Args:
-        login_customer_id: a str from config indicating a login customer ID.
-
-    Raises:
-        ValueError: If the login customer ID is not an int in the
-            range 0 - 9999999999.
-    """
-    if login_customer_id is not None:
-        if not login_customer_id.isdigit() or len(login_customer_id) != 10:
-            raise ValueError('The specified login customer ID is invalid. '
-                             'It must be a ten digit number represented '
-                             'as a string, i.e. "1234567890"')
 
 
 def _format_json_object(obj):

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -111,18 +111,7 @@ class GoogleAdsClient(object):
             ValueError: If the environment lacks a required field or
                 GOOGLE_ADS_LOGGING env variable is not in JSON format.
         """
-        config_data = {
-            key: os.environ[env_variable]
-            for key, env_variable in config._KEYS_ENV_VARIABLES_MAP.items()
-            if env_variable in os.environ
-        }
-        if 'logging' in config_data.keys():
-            try:
-                config_data['logging'] = json.loads(config_data['logging'])
-            except json.JSONDecodeError:
-                raise ValueError(
-                    'GOOGLE_ADS_LOGGING env variable should be in JSON format.'
-                )
+        config_data = config.load_from_env()
         return cls._get_client_kwargs(
             config_data,
             'A required variable was not found in the environment. The '
@@ -146,6 +135,7 @@ class GoogleAdsClient(object):
         Raises:
             ValueError: If the configuration lacks a required field.
         """
+
         return cls(**cls._get_client_kwargs_from_env())
 
     @classmethod

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -147,27 +147,6 @@ class GoogleAdsClient(object):
         )
 
     @classmethod
-    def _get_client_kwargs_from_yaml(cls, yaml_str):
-        """Utility function used to load client kwargs from YAML string.
-
-        Args:
-            yaml_str: a str containing client configuration in YAML format.
-
-        Returns:
-            A dict containing configuration data that will be provided to the
-            GoogleAdsClient initializer as keyword arguments.
-
-        Raises:
-            ValueError: If the configuration lacks a required field.
-        """
-        config_data = yaml.safe_load(yaml_str) or {}
-        return cls._get_client_kwargs(
-            config_data,
-            'A required field in the configuration data was not found. The '
-            'required fields are: %s' % str(_REQUIRED_KEYS)
-        )
-
-    @classmethod
     def get_type(cls, name, version=_DEFAULT_VERSION):
         """Returns the specified common, enum, error, or resource type.
 
@@ -220,7 +199,12 @@ class GoogleAdsClient(object):
         Raises:
             ValueError: If the configuration lacks a required field.
         """
-        return cls(**cls._get_client_kwargs_from_yaml(yaml_str))
+        config_data = config.parse_yaml_document_to_dict(yaml_str)
+        kwargs = cls._get_client_kwargs(
+            config_data,
+            'A required field in the configuration data was not found. The '
+            'required fields are: {}'.format(str(_REQUIRED_KEYS)))
+        return cls(**kwargs)
 
     @classmethod
     def load_from_storage(cls, path=None):
@@ -243,7 +227,7 @@ class GoogleAdsClient(object):
         kwargs = cls._get_client_kwargs(
             config_data,
             'A required field in the configuration data was not found. The '
-            'required fields are: %s' % str(_REQUIRED_KEYS))
+            'required fields are: {}'.format(str(_REQUIRED_KEYS)))
         return cls(**kwargs)
 
     def __init__(self, credentials, developer_token, endpoint=None,

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -15,15 +15,12 @@
 
 import logging
 import logging.config
-import os
-import yaml
 import json
 import grpc
 from collections import namedtuple
 from importlib import import_module
 
 from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials as InstalledAppCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCreds
 from google.protobuf.message import DecodeError
 

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -61,8 +61,7 @@ class GoogleAdsClient(object):
         Raises:
             ValueError: If the configuration lacks a required field.
         """
-        if not all(key in config_data for key in config._REQUIRED_KEYS):
-            raise ValueError(error_message)
+        config.validate_dict(config_data, error_message)
 
         if all(key in config_data for key in config._OAUTH2_INSTALLED_APP_KEYS):
             # Using the Installed App Flow
@@ -97,7 +96,6 @@ class GoogleAdsClient(object):
                 'endpoint': config_data.get('endpoint'),
                 'login_customer_id': login_customer_id,
                 'logging_config': config_data.get('logging')}
-
 
     @classmethod
     def _get_client_kwargs_from_env(cls):

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -125,8 +125,7 @@ class GoogleAdsClient(object):
             name: a str indicating the name of the type that is being retrieved;
                 e.g. you may specify "CampaignOperation" to retrieve a
                 CampaignOperation instance.
-            version: a str indicating the version of the Google Ads API to be
-                used.
+            version: a str indicating the the Google Ads API version to be used.
 
         Returns:
             A Message instance representing the desired type.
@@ -138,8 +137,8 @@ class GoogleAdsClient(object):
         try:
             message_type = getattr(_get_version(version).types, name)
         except AttributeError:
-            raise ValueError('Specified type "%s" does not exist in Google Ads '
-                             'API %s.' % (name, version))
+            raise ValueError('Specified type "{}" does not exist in Google Ads '
+                             'API %s.'.format(name, version))
         return message_type()
 
     def __init__(self, credentials, developer_token, endpoint=None,

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -25,8 +25,10 @@ from importlib import import_module
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials as InstalledAppCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCreds
-from google.ads.google_ads.errors import GoogleAdsException
 from google.protobuf.message import DecodeError
+
+from google.ads.google_ads import config
+from google.ads.google_ads.errors import GoogleAdsException
 
 _logger = logging.getLogger(__name__)
 
@@ -237,16 +239,12 @@ class GoogleAdsClient(object):
             IOError: If the configuration file can't be loaded.
             ValueError: If the configuration file lacks a required field.
         """
-        if path is None:
-            path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
-
-        if not os.path.isabs(path):
-            path = os.path.expanduser(path)
-
-        with open(path, 'rb') as handle:
-            yaml_str = handle.read()
-
-        return cls.load_from_string(yaml_str)
+        config_data = config.load_from_yaml_file(path)
+        kwargs = cls._get_client_kwargs(
+            config_data,
+            'A required field in the configuration data was not found. The '
+            'required fields are: %s' % str(_REQUIRED_KEYS))
+        return cls(**kwargs)
 
     def __init__(self, credentials, developer_token, endpoint=None,
                  login_customer_id=None, logging_config=None):

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -33,6 +33,7 @@ from google.ads.google_ads.errors import GoogleAdsException
 _logger = logging.getLogger(__name__)
 
 _REQUIRED_KEYS = ('developer_token',)
+_OPTIONAL_KEYS = ('login_customer_id', 'endpoint', 'logging')
 _OAUTH2_INSTALLED_APP_KEYS = ('client_id', 'client_secret', 'refresh_token')
 _OAUTH2_SERVICE_ACCOUNT_KEYS = ('path_to_private_key_file', 'delegated_account')
 _SERVICE_ACCOUNT_SCOPES = ['https://www.googleapis.com/auth/adwords']
@@ -47,7 +48,7 @@ _ENV_PREFIX = 'GOOGLE_ADS_'
 _KEYS_ENV_VARIABLES_MAP = {
     key: _ENV_PREFIX + key.upper() for key in
     list(_REQUIRED_KEYS) +
-    ['login_customer_id', 'endpoint', 'logging'] +
+    list(_OPTIONAL_KEYS) +
     list(_OAUTH2_INSTALLED_APP_KEYS) +
     list(_OAUTH2_SERVICE_ACCOUNT_KEYS)
 }
@@ -147,31 +148,6 @@ class GoogleAdsClient(object):
         )
 
     @classmethod
-    def get_type(cls, name, version=_DEFAULT_VERSION):
-        """Returns the specified common, enum, error, or resource type.
-
-        Args:
-            name: a str indicating the name of the type that is being retrieved;
-                e.g. you may specify "CampaignOperation" to retrieve a
-                CampaignOperation instance.
-            version: a str indicating the version of the Google Ads API to be
-                used.
-
-        Returns:
-            A Message instance representing the desired type.
-
-        Raises:
-            AttributeError: If the type for the specified name doesn't exist
-                in the given version.
-        """
-        try:
-            message_type = getattr(_get_version(version).types, name)
-        except AttributeError:
-            raise ValueError('Specified type "%s" does not exist in Google Ads '
-                             'API %s.' % (name, version))
-        return message_type()
-
-    @classmethod
     def load_from_env(cls):
         """Creates a GoogleAdsClient with data stored in the env variables.
 
@@ -204,6 +180,7 @@ class GoogleAdsClient(object):
             config_data,
             'A required field in the configuration data was not found. The '
             'required fields are: {}'.format(str(_REQUIRED_KEYS)))
+
         return cls(**kwargs)
 
     @classmethod
@@ -228,7 +205,33 @@ class GoogleAdsClient(object):
             config_data,
             'A required field in the configuration data was not found. The '
             'required fields are: {}'.format(str(_REQUIRED_KEYS)))
+
         return cls(**kwargs)
+
+    @classmethod
+    def get_type(cls, name, version=_DEFAULT_VERSION):
+        """Returns the specified common, enum, error, or resource type.
+
+        Args:
+            name: a str indicating the name of the type that is being retrieved;
+                e.g. you may specify "CampaignOperation" to retrieve a
+                CampaignOperation instance.
+            version: a str indicating the version of the Google Ads API to be
+                used.
+
+        Returns:
+            A Message instance representing the desired type.
+
+        Raises:
+            AttributeError: If the type for the specified name doesn't exist
+                in the given version.
+        """
+        try:
+            message_type = getattr(_get_version(version).types, name)
+        except AttributeError:
+            raise ValueError('Specified type "%s" does not exist in Google Ads '
+                             'API %s.' % (name, version))
+        return message_type()
 
     def __init__(self, credentials, developer_token, endpoint=None,
                  login_customer_id=None, logging_config=None):

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -40,44 +40,24 @@ class GoogleAdsClient(object):
 
     @classmethod
     def _get_client_kwargs(cls, config_data):
-        """Utility function used to load client kwargs from configuration data
-        dictionary.
+        """Converts configuration dict into kwargs required by the client.
 
         Args:
             config_data: a dict containing client configuration.
 
         Returns:
-            A dict containing configuration data that will be provided to the
-            GoogleAdsClient initializer as keyword arguments.
+            A dict containing kwargs that will be provided to the
+            GoogleAdsClient initializer.
 
         Raises:
             ValueError: If the configuration lacks a required field.
         """
-        if all(key in config_data for key in config._OAUTH2_INSTALLED_APP_KEYS):
-            # Using the Installed App Flow
-            credentials = oauth2.get_installed_app_credentials(
-                config_data.get('client_id'),
-                config_data.get('client_secret'),
-                config_data.get('refresh_token'))
-        elif all(key in config_data for key in config._OAUTH2_SERVICE_ACCOUNT_KEYS):
-            # Using the Service Account Flow
-            credentials = oauth2.get_service_account_credentials(
-                config_data.get('path_to_private_key_file'),
-                config_data.get('delegated_account'))
-        else:
-            raise ValueError('Your yaml file is incorrectly configured for '
-                             'OAuth2. You need to specify credentials for '
-                             'either the OAuth2 installed application flow '
-                             '({}) or service account flow ({}).'.format(
-                config._OAUTH2_INSTALLED_APP_KEYS,
-                config._OAUTH2_SERVICE_ACCOUNT_KEYS))
-
         login_customer_id = config_data.get('login_customer_id')
         login_customer_id = str(
                 login_customer_id) if login_customer_id else None
 
-        return {'credentials': credentials,
-                'developer_token': config_data['developer_token'],
+        return {'credentials': oauth2.get_credentials(config_data),
+                'developer_token': config_data.get('developer_token'),
                 'endpoint': config_data.get('endpoint'),
                 'login_customer_id': login_customer_id,
                 'logging_config': config_data.get('logging')}
@@ -95,7 +75,6 @@ class GoogleAdsClient(object):
         """
         config_data = config.load_from_env()
         kwargs = cls._get_client_kwargs(config_data)
-
         return cls(**kwargs)
 
     @classmethod
@@ -115,7 +94,6 @@ class GoogleAdsClient(object):
         """
         config_data = config.parse_yaml_document_to_dict(yaml_str)
         kwargs = cls._get_client_kwargs(config_data)
-
         return cls(**kwargs)
 
     @classmethod
@@ -137,7 +115,6 @@ class GoogleAdsClient(object):
         """
         config_data = config.load_from_yaml_file(path)
         kwargs = cls._get_client_kwargs(config_data)
-
         return cls(**kwargs)
 
     @classmethod

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -154,3 +154,21 @@ def load_from_env():
                 'GOOGLE_ADS_LOGGING env variable should be in JSON format.')
 
     return config_data
+
+
+def get_oauth2_installed_app_keys():
+    """A getter that returns the required OAuth2 installed application keys.
+
+    Returns:
+        A tuple containing the required keys as strs.
+    """
+    return _OAUTH2_INSTALLED_APP_KEYS
+
+
+def get_oauth2_service_account_keys():
+    """A getter that returns the required OAuth2 service account keys.
+
+    Returns:
+        A tuple containing the required keys as strs.
+    """
+    return _OAUTH2_SERVICE_ACCOUNT_KEYS

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 """A set of functions to help load configuration from various locations."""
 
+import json
 import os
 import yaml
 
+from google.ads.google_ads import client
+
 def load_from_yaml_file(path=None):
-    """Creates a GoogleAdsClient with data stored in the specified file.
+    """Loads configuration data from a YAML file and returns it as a dict.
 
     Args:
         path: a str indicating the path to a YAML file containing
@@ -56,3 +59,27 @@ def parse_yaml_document_to_dict(yaml_doc):
         yaml.YAMLError: If there is a problem parsing the YAML document.
     """
     return yaml.safe_load(yaml_doc) or {}
+
+
+def load_from_env():
+    """Loads configuration data from the environment and returns it as a dict.
+
+    Returns:
+        A dict with configuration from the environment.
+
+    Raises:
+        ValueError: If the configuration
+    """
+    config_data = {
+        key: os.environ[env_variable]
+        for key, env_variable in client._KEYS_ENV_VARIABLES_MAP.items()
+        if env_variable in os.environ
+    }
+    if 'logging' in config_data.keys():
+        try:
+            config_data['logging'] = json.loads(config_data['logging'])
+        except json.JSONDecodeError:
+            raise ValueError(
+                'GOOGLE_ADS_LOGGING env variable should be in JSON format.')
+
+    return config_data

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A set of functions to help load configuration from various locations."""
+
+import os
+import yaml
+
+def load_from_yaml_file(path=None):
+    """Creates a GoogleAdsClient with data stored in the specified file.
+
+    Args:
+        path: a str indicating the path to a YAML file containing
+            configuration data used to initialize a GoogleAdsClient.
+
+    Returns:
+        A GoogleAdsClient initialized with the values in the specified file.
+
+    Raises:
+        FileNotFoundError: If the specified configuration file doesn't exist.
+        IOError: If the configuration file can't be loaded.
+        yaml.YAMLError: If there is a problem parsing the YAML document.
+    """
+    if path is None:
+        path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
+
+    if not os.path.isabs(path):
+        path = os.path.expanduser(path)
+
+    with open(path, 'rb') as handle:
+        yaml_str = handle.read()
+
+    return yaml.safe_load(yaml_str) or {}

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -98,16 +98,45 @@ def load_from_env():
     return config_data
 
 
-def validate_dict(config_data, error_message=_MISSING_CONFIG_ERROR_MESSAGE):
-    """Validates that all required keys are present in configuration
+def validate_dict(config_data,
+                  required_keys_error_message=_MISSING_CONFIG_ERROR_MESSAGE):
+    """Validates the given configuration dict.
+
+    Validations that are performed include:
+        1. Ensuring all required keys are present.
+        2. If a login_customer_id is present ensure it's valid
 
     Args:
         config_data: a dict with configuration data.
-        error_message: an optional error message str to raise if validation
-            fails.
+        required_keys_error_message: an optional error message str to raise if
+            the given config does not contain all required keys. This is
+            configurable so that error messages can be more specific since key
+            names may vary depending on where config values are retrieved. For
+            example "client_id" is "GOOGLE_ADS_CLIENT_ID" when retrieved from
+            env.
 
     Raises:
         ValueError: If the dict does not contain all required config keys.
     """
     if not all(key in config_data for key in _REQUIRED_KEYS):
-        raise ValueError(error_message)
+        raise ValueError(required_keys_error_message)
+
+    if 'login_customer_id' in config_data:
+        validate_login_customer_id(config_data['login_customer_id'])
+
+
+def validate_login_customer_id(login_customer_id):
+    """Validates a login customer ID.
+
+    Args:
+        login_customer_id: a str from config indicating a login customer ID.
+
+    Raises:
+        ValueError: If the login customer ID is not an int in the
+            range 0 - 9999999999.
+    """
+    if login_customer_id is not None:
+        if not login_customer_id.isdigit() or len(login_customer_id) != 10:
+            raise ValueError('The specified login customer ID is invalid. '
+                             'It must be a ten digit number represented '
+                             'as a string, i.e. "1234567890"')

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -24,12 +24,11 @@ def load_from_yaml_file(path=None):
             configuration data used to initialize a GoogleAdsClient.
 
     Returns:
-        A GoogleAdsClient initialized with the values in the specified file.
+        A dict with configuration from the specified YAML file.
 
     Raises:
         FileNotFoundError: If the specified configuration file doesn't exist.
         IOError: If the configuration file can't be loaded.
-        yaml.YAMLError: If there is a problem parsing the YAML document.
     """
     if path is None:
         path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
@@ -38,6 +37,22 @@ def load_from_yaml_file(path=None):
         path = os.path.expanduser(path)
 
     with open(path, 'rb') as handle:
-        yaml_str = handle.read()
+        yaml_doc = handle.read()
 
-    return yaml.safe_load(yaml_str) or {}
+    return parse_yaml_document_to_dict(yaml_doc)
+
+
+def parse_yaml_document_to_dict(yaml_doc):
+    """Parses a YAML document to a dict.
+
+    Args:
+        yaml_doc: a str (in Python 2) or bytes (in Python 3) containing YAML
+            configuration data.
+
+    Returns:
+        A dict of the key/value pairs from the given YAML document.
+
+    Raises:
+        yaml.YAMLError: If there is a problem parsing the YAML document.
+    """
+    return yaml.safe_load(yaml_doc) or {}

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -17,7 +17,18 @@ import json
 import os
 import yaml
 
-from google.ads.google_ads import client
+_ENV_PREFIX = 'GOOGLE_ADS_'
+_REQUIRED_KEYS = ('developer_token',)
+_OPTIONAL_KEYS = ('login_customer_id', 'endpoint', 'logging')
+_OAUTH2_INSTALLED_APP_KEYS = ('client_id', 'client_secret', 'refresh_token')
+_OAUTH2_SERVICE_ACCOUNT_KEYS = ('path_to_private_key_file', 'delegated_account')
+_KEYS_ENV_VARIABLES_MAP = {
+    key: _ENV_PREFIX + key.upper() for key in
+    list(_REQUIRED_KEYS) +
+    list(_OPTIONAL_KEYS) +
+    list(_OAUTH2_INSTALLED_APP_KEYS) +
+    list(_OAUTH2_SERVICE_ACCOUNT_KEYS)
+}
 
 def load_from_yaml_file(path=None):
     """Loads configuration data from a YAML file and returns it as a dict.
@@ -72,7 +83,7 @@ def load_from_env():
     """
     config_data = {
         key: os.environ[env_variable]
-        for key, env_variable in client._KEYS_ENV_VARIABLES_MAP.items()
+        for key, env_variable in _KEYS_ENV_VARIABLES_MAP.items()
         if env_variable in os.environ
     }
     if 'logging' in config_data.keys():

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -34,8 +34,7 @@ _KEYS_ENV_VARIABLES_MAP = {
 def _config_validation_decorator(func):
     """A decorator used to easily run validations on configs loaded into dicts.
 
-    Add this decorator to any new methods in this module that read library
-    configuration and return it as a dict.
+    Add this decorator to any method that returns the config as a dict.
 
     Raises:
         ValueError: If the configuration fails validation

--- a/google/ads/google_ads/config.py
+++ b/google/ads/google_ads/config.py
@@ -27,8 +27,10 @@ _KEYS_ENV_VARIABLES_MAP = {
     list(_REQUIRED_KEYS) +
     list(_OPTIONAL_KEYS) +
     list(_OAUTH2_INSTALLED_APP_KEYS) +
-    list(_OAUTH2_SERVICE_ACCOUNT_KEYS)
-}
+    list(_OAUTH2_SERVICE_ACCOUNT_KEYS)}
+_MISSING_CONFIG_ERROR_MESSAGE = ('A required field in the configuration data '
+                                 'was not found. The required fields are: {}'
+                                 ''.format(str(_REQUIRED_KEYS)))
 
 def load_from_yaml_file(path=None):
     """Loads configuration data from a YAML file and returns it as a dict.
@@ -94,3 +96,18 @@ def load_from_env():
                 'GOOGLE_ADS_LOGGING env variable should be in JSON format.')
 
     return config_data
+
+
+def validate_dict(config_data, error_message=_MISSING_CONFIG_ERROR_MESSAGE):
+    """Validates that all required keys are present in configuration
+
+    Args:
+        config_data: a dict with configuration data.
+        error_message: an optional error message str to raise if validation
+            fails.
+
+    Raises:
+        ValueError: If the dict does not contain all required config keys.
+    """
+    if not all(key in config_data for key in _REQUIRED_KEYS):
+        raise ValueError(error_message)

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A set of functions to help initialize OAuth2 credentials."""
+
+from google.oauth2.credentials import Credentials as InstalledAppCredentials
+from google.auth.transport.requests import Request
+
+def get_installed_app_credentials(
+    client_id, client_secret, refresh_token, token_uri):
+    credentials = InstalledAppCredentials(
+        None, client_id=client_id, client_secret=client_secret,
+        refresh_token=refresh_token, token_uri=token_uri)
+
+    credentials.refresh(Request())
+    return credentials

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -94,6 +94,11 @@ def get_credentials(config_data):
             config_data.get('client_id'),
             config_data.get('client_secret'),
             config_data.get('refresh_token'))
+    elif all(key in config_data for key in required_service_account_keys):
+        # Using the Service Account Flow
+        return get_service_account_credentials(
+            config_data.get('path_to_private_key_file'),
+            config_data.get('delegated_account'))
     else:
         raise ValueError('Your yaml file is incorrectly configured for OAuth2. '
                          'You need to define credentials for either the OAuth2 '

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -20,6 +20,8 @@ from google.oauth2.service_account import Credentials as ServiceAccountCreds
 from google.oauth2.credentials import Credentials as InstalledAppCredentials
 from google.auth.transport.requests import Request
 
+from google.ads.google_ads import config
+
 _SERVICE_ACCOUNT_SCOPES = ['https://www.googleapis.com/auth/adwords']
 _DEFAULT_TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
 
@@ -72,3 +74,21 @@ def get_service_account_credentials(path_to_private_key_file, subject,
     """
     return ServiceAccountCreds.from_service_account_file(
         path_to_private_key_file, subject=subject, scopes=scopes)
+
+
+def get_credentials(config_data):
+    """Decides which type of credentials to return based on the given config.
+
+    Args:
+        config_data: a dict containing client configuration.
+
+    Returns:
+        An initialized credentials instance.
+    """
+    required_installed_app_keys = config.get_oauth2_installed_app_keys()
+    if all(key in config_data for key in required_installed_app_keys):
+        # Using the Installed App Flow
+        return get_installed_app_credentials(
+            config_data.get('client_id'),
+            config_data.get('client_secret'),
+            config_data.get('refresh_token'))

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -100,7 +100,7 @@ def get_credentials(config_data):
             config_data.get('path_to_private_key_file'),
             config_data.get('delegated_account'))
     else:
-        raise ValueError('Your yaml file is incorrectly configured for OAuth2. '
+        raise ValueError('Your YAML file is incorrectly configured for OAuth2. '
                          'You need to define credentials for either the OAuth2 '
                          'installed application flow ({}) or service account '
                          'flow ({}).'.format(required_installed_app_keys,

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -86,9 +86,17 @@ def get_credentials(config_data):
         An initialized credentials instance.
     """
     required_installed_app_keys = config.get_oauth2_installed_app_keys()
+    required_service_account_keys = config.get_oauth2_service_account_keys()
+
     if all(key in config_data for key in required_installed_app_keys):
         # Using the Installed App Flow
         return get_installed_app_credentials(
             config_data.get('client_id'),
             config_data.get('client_secret'),
             config_data.get('refresh_token'))
+    else:
+        raise ValueError('Your yaml file is incorrectly configured for OAuth2. '
+                         'You need to define credentials for either the OAuth2 '
+                         'installed application flow ({}) or service account '
+                         'flow ({}).'.format(required_installed_app_keys,
+                                             required_service_account_keys))

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -13,14 +13,30 @@
 # limitations under the License.
 """A set of functions to help initialize OAuth2 credentials."""
 
+
+from google.oauth2.service_account import Credentials as ServiceAccountCreds
 from google.oauth2.credentials import Credentials as InstalledAppCredentials
 from google.auth.transport.requests import Request
+
+_SERVICE_ACCOUNT_SCOPES = ['https://www.googleapis.com/auth/adwords']
+
 
 def get_installed_app_credentials(
     client_id, client_secret, refresh_token, token_uri):
     credentials = InstalledAppCredentials(
         None, client_id=client_id, client_secret=client_secret,
         refresh_token=refresh_token, token_uri=token_uri)
+
+    credentials.refresh(Request())
+    return credentials
+
+
+def get_service_account_credentials(path_to_private_key_file, subject,
+                                    scopes=_SERVICE_ACCOUNT_SCOPES):
+    credentials = ServiceAccountCreds.from_service_account_file(
+        path_to_private_key_file,
+        subject=subject,
+        scopes=scopes)
 
     credentials.refresh(Request())
     return credentials

--- a/google/ads/google_ads/oauth2.py
+++ b/google/ads/google_ads/oauth2.py
@@ -19,10 +19,20 @@ from google.oauth2.credentials import Credentials as InstalledAppCredentials
 from google.auth.transport.requests import Request
 
 _SERVICE_ACCOUNT_SCOPES = ['https://www.googleapis.com/auth/adwords']
-
+_DEFAULT_TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
 
 def get_installed_app_credentials(
-    client_id, client_secret, refresh_token, token_uri):
+    client_id, client_secret, refresh_token, token_uri=_DEFAULT_TOKEN_URI):
+    """Creates and returns an instance of oauth2.credentials.Credentials.
+
+    Args:
+        client_id: A str of the oauth2 client_id from configuration.
+        client_secret: A str of the oauth2 client_secret from configuration.
+        refresh_token: A str of the oauth2 refresh_token from configuration.
+
+    Returns:
+        An instance of oauth2.credentials.Credentials
+    """
     credentials = InstalledAppCredentials(
         None, client_id=client_id, client_secret=client_secret,
         refresh_token=refresh_token, token_uri=token_uri)
@@ -33,6 +43,17 @@ def get_installed_app_credentials(
 
 def get_service_account_credentials(path_to_private_key_file, subject,
                                     scopes=_SERVICE_ACCOUNT_SCOPES):
+    """Creates and returns an instance of oauth2.service_account.Credentials.
+
+    Args:
+        path_to_private_key_file: A str of the path to the private key file
+            location.
+        subject: A str of the email address of the delegated account.
+        scopes: A list of additional scopes.
+
+    Returns:
+        An instance of oauth2.credentials.Credentials
+    """
     credentials = ServiceAccountCreds.from_service_account_file(
         path_to_private_key_file,
         subject=subject,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for the Google Ads API client library."""
 
-
 import os
 import mock
 import yaml
@@ -49,7 +48,7 @@ class ModuleLevelTest(TestCase):
             ('developer-token', '0000000000'),
             ('login-customer-id', '9999999999')]
 
-        result = (Client._parse_metadata_to_json(mock_metadata))
+        result = Client._parse_metadata_to_json(mock_metadata)
 
         self.assertEqual(result, '{\n'
                                  '  "developer-token": "REDACTED",\n'
@@ -110,15 +109,14 @@ class GoogleAdsClientTest(FileTestCase):
             'client_id': self.client_id,
             'client_secret': self.client_secret,
             'refresh_token': self.refresh_token,
-            'login_customer_id': self.login_customer_id
-        }
+            'login_customer_id': self.login_customer_id}
+        mock_credentials_instance = mock.Mock()
 
-        with mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
-        ) as mock_credentials:
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
-            result = Client.GoogleAdsClient._get_client_kwargs(config, '')
+        with mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance):
+            result = Client.GoogleAdsClient._get_client_kwargs(config)
             self.assertEqual(
                 result,
                 {
@@ -135,15 +133,14 @@ class GoogleAdsClientTest(FileTestCase):
             'client_id': self.client_id,
             'client_secret': self.client_secret,
             'refresh_token': self.refresh_token,
-            'login_customer_id': None
-        }
+            'login_customer_id': None}
+        mock_credentials_instance = mock.Mock()
 
-        with mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
-        ) as mock_credentials:
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
-            result = Client.GoogleAdsClient._get_client_kwargs(config, '')
+        with mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance):
+            result = Client.GoogleAdsClient._get_client_kwargs(config)
             self.assertEqual(
                 result,
                 {
@@ -159,15 +156,14 @@ class GoogleAdsClientTest(FileTestCase):
             'developer_token': self.developer_token,
             'client_id': self.client_id,
             'client_secret': self.client_secret,
-            'refresh_token': self.refresh_token
-        }
+            'refresh_token': self.refresh_token}
+        mock_credentials_instance = mock.Mock()
 
-        with mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
-        ) as mock_credentials:
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
-            result = (Client.GoogleAdsClient._get_client_kwargs(config, ''))
+        with mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance):
+            result = Client.GoogleAdsClient._get_client_kwargs(config)
             self.assertEqual(
                 result,
                 {
@@ -185,15 +181,14 @@ class GoogleAdsClientTest(FileTestCase):
             'client_id': self.client_id,
             'client_secret': self.client_secret,
             'refresh_token': self.refresh_token,
-            'endpoint': endpoint
-        }
+            'endpoint': endpoint}
+        mock_credentials_instance = mock.Mock()
 
-        with mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
-        ) as mock_credentials:
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
-            result = Client.GoogleAdsClient._get_client_kwargs(config, '')
+        with mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance):
+            result = Client.GoogleAdsClient._get_client_kwargs(config)
             self.assertEqual(
                 result,
                 {
@@ -213,22 +208,23 @@ class GoogleAdsClientTest(FileTestCase):
 
         file_path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
         self.fs.create_file(file_path, contents=yaml.safe_dump(config))
+        mock_credentials_instance = mock.Mock()
 
-        with mock.patch(
-            'google.ads.google_ads.client.GoogleAdsClient.__init__'
-        ) as mock_client_init, mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
+        with mock.patch.object(
+            Client.GoogleAdsClient,
+            '__init__',
+            return_value=None
+        ) as mock_client_init, mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance
         ) as mock_credentials:
-            mock_client_init.return_value = None
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
             Client.GoogleAdsClient.load_from_storage()
             mock_credentials.assert_called_once_with(
-                None,
-                refresh_token=config.get('refresh_token'),
-                client_id=config.get('client_id'),
-                client_secret=config.get('client_secret'),
-                token_uri=Client._DEFAULT_TOKEN_URI)
+                config.get('client_id'),
+                config.get('client_secret'),
+                config.get('refresh_token'),
+                Client._DEFAULT_TOKEN_URI)
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,
@@ -241,20 +237,20 @@ class GoogleAdsClientTest(FileTestCase):
             'developer_token': self.developer_token,
             'client_id': self.client_id,
             'client_secret': self.client_secret,
-            'refresh_token': self.refresh_token
-        }
+            'refresh_token': self.refresh_token}
 
         file_path = 'test/google-ads.yaml'
         self.fs.create_file(file_path, contents=yaml.safe_dump(config))
+        mock_credentials_instance = mock.Mock()
 
-        with mock.patch(
-            'google.ads.google_ads.client.GoogleAdsClient.__init__'
-        ) as mock_client_init, mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
-        ) as mock_credentials:
-            mock_client_init.return_value = None
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
+        with mock.patch.object(
+            Client.GoogleAdsClient,
+            '__init__',
+            return_value=None
+        ) as mock_client_init, mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance):
             Client.GoogleAdsClient.load_from_storage(path=file_path)
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -241,33 +241,6 @@ class GoogleAdsClientTest(FileTestCase):
                         'logging_config': {'test': True}
                     })
 
-    def test_get_client_kwargs_from_yaml(self):
-        config = {
-            'developer_token': self.developer_token,
-            'client_id': self.client_id,
-            'client_secret': self.client_secret,
-            'refresh_token': self.refresh_token
-        }
-
-        yaml_str = yaml.safe_dump(config)
-
-        with mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
-        ) as mock_credentials:
-            mock_credentials_instance = mock.Mock()
-            mock_credentials.return_value = mock_credentials_instance
-            result = Client.GoogleAdsClient._get_client_kwargs_from_yaml(
-                yaml_str)
-            self.assertEqual(
-                result,
-                {
-                    'credentials': mock_credentials_instance,
-                    'developer_token': self.developer_token,
-                    'endpoint': None,
-                    'login_customer_id': None,
-                    'logging_config': None
-                })
-
     def test_load_from_storage(self):
         config = {
             'developer_token': self.developer_token,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -42,18 +42,6 @@ google_ads_service_pb2 = services.google_ads_service_pb2
 
 class ModuleLevelTest(TestCase):
 
-    def test_validate_login_customer_id_invalid(self):
-        self.assertRaises(
-            ValueError,
-            Client._validate_login_customer_id,
-            '123-456-7890')
-
-    def test_validate_login_customer_id_too_short(self):
-        self.assertRaises(
-            ValueError,
-            Client._validate_login_customer_id,
-            '123')
-
     def test_parse_metadata_to_json(self):
         mock_metadata = [
             ('x-goog-api-client',
@@ -216,38 +204,12 @@ class GoogleAdsClientTest(FileTestCase):
                     'logging_config': None
                 })
 
-    def test_get_client_kwargs_from_env(self):
-        environ = {
-            'GOOGLE_ADS_DEVELOPER_TOKEN': self.developer_token,
-            'GOOGLE_ADS_CLIENT_ID': self.client_id,
-            'GOOGLE_ADS_CLIENT_SECRET': self.client_secret,
-            'GOOGLE_ADS_REFRESH_TOKEN': self.refresh_token,
-            'GOOGLE_ADS_LOGGING': '{"test": true}'
-        }
-        with mock.patch('os.environ', environ):
-            with mock.patch(
-                'google.ads.google_ads.client.InstalledAppCredentials'
-            ) as mock_credentials:
-                mock_credentials_instance = mock.Mock()
-                mock_credentials.return_value = mock_credentials_instance
-                result = Client.GoogleAdsClient._get_client_kwargs_from_env()
-                self.assertEqual(
-                    result,
-                    {
-                        'credentials': mock_credentials_instance,
-                        'developer_token': self.developer_token,
-                        'endpoint': None,
-                        'login_customer_id': None,
-                        'logging_config': {'test': True}
-                    })
-
     def test_load_from_storage(self):
         config = {
             'developer_token': self.developer_token,
             'client_id': self.client_id,
             'client_secret': self.client_secret,
-            'refresh_token': self.refresh_token
-        }
+            'refresh_token': self.refresh_token}
 
         file_path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
         self.fs.create_file(file_path, contents=yaml.safe_dump(config))
@@ -377,14 +339,6 @@ class GoogleAdsClientTest(FileTestCase):
             self.assertRaises(
                 ValueError,
                 Client.GoogleAdsClient.load_from_storage)
-
-    def test_init_validate_login_customer_id(self):
-        with mock.patch(
-            'google.ads.google_ads.client._validate_login_customer_id'
-        ) as f:
-            Client.GoogleAdsClient(
-                None, None, login_customer_id='1234567890')
-            self.assertTrue(f.called)
 
     def test_get_service(self):
         # Retrieve service names for all defined service clients.

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -224,8 +224,7 @@ class GoogleAdsClientTest(FileTestCase):
             mock_credentials.assert_called_once_with(
                 config.get('client_id'),
                 config.get('client_secret'),
-                config.get('refresh_token'),
-                Client._DEFAULT_TOKEN_URI)
+                config.get('refresh_token'))
             mock_client_init.assert_called_once_with(
                 credentials=mock_credentials_instance,
                 developer_token=self.developer_token,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -92,7 +92,7 @@ class GoogleAdsClientTest(FileTestCase):
 
     def _create_test_client(self, endpoint=None):
         with mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_credentials_instance = mock_credentials.return_value
             mock_credentials_instance.refresh_token = self.refresh_token
             mock_credentials_instance.client_id = self.client_id
@@ -119,7 +119,7 @@ class GoogleAdsClientTest(FileTestCase):
         }
 
         with mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             result = (Client.GoogleAdsClient.
@@ -144,7 +144,7 @@ class GoogleAdsClientTest(FileTestCase):
         }
 
         with mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             result = (Client.GoogleAdsClient.
@@ -168,7 +168,7 @@ class GoogleAdsClientTest(FileTestCase):
         }
 
         with mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             result = (Client.GoogleAdsClient._get_client_kwargs(config, ''))
@@ -193,7 +193,7 @@ class GoogleAdsClientTest(FileTestCase):
         }
 
         with mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             result = (Client.GoogleAdsClient.
@@ -218,12 +218,11 @@ class GoogleAdsClientTest(FileTestCase):
         }
         with mock.patch('os.environ', environ):
             with mock.patch(
-                'google.ads.google_ads.client.Credentials'
+                'google.ads.google_ads.client.InstalledAppCredentials'
             ) as mock_credentials:
                 mock_credentials_instance = mock.Mock()
                 mock_credentials.return_value = mock_credentials_instance
-                result = (Client.GoogleAdsClient.
-                          _get_client_kwargs_from_env())
+                result = Client.GoogleAdsClient._get_client_kwargs_from_env()
                 self.assertEqual(
                     result,
                     {
@@ -245,7 +244,7 @@ class GoogleAdsClientTest(FileTestCase):
         yaml_str = yaml.safe_dump(config)
 
         with mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
             result = (Client.GoogleAdsClient._get_client_kwargs_from_yaml(
@@ -274,7 +273,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance
@@ -300,7 +299,7 @@ class GoogleAdsClientTest(FileTestCase):
         with mock.patch('google.ads.google_ads.client.GoogleAdsClient'
                         '.__init__') as mock_client_init, \
             mock.patch(
-                'google.ads.google_ads.client.Credentials') as mock_credentials:
+                'google.ads.google_ads.client.InstalledAppCredentials') as mock_credentials:
             mock_client_init.return_value = None
             mock_credentials_instance = mock.Mock()
             mock_credentials.return_value = mock_credentials_instance

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -81,8 +81,9 @@ class GoogleAdsClientTest(FileTestCase):
     """Tests for the google.ads.googleads.client.GoogleAdsClient class."""
 
     def _create_test_client(self, endpoint=None):
-        with mock.patch(
-            'google.ads.google_ads.client.InstalledAppCredentials'
+        with mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials'
         ) as mock_credentials:
             mock_credentials_instance = mock_credentials.return_value
             mock_credentials_instance.refresh_token = self.refresh_token

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests the configuration helper module."""
 
+import mock
 import os
 import yaml
 from pyfakefs.fake_filesystem_unittest import TestCase as FileTestCase
@@ -29,7 +30,7 @@ class ConfigTest(FileTestCase):
         self.login_customer_id = '1234567890'
         self.path_to_private_key_file = '/test/path/to/config.json'
         self.delegated_account = 'delegated@account.com'
-
+        self.endpoint = 'www.testendpoint.com'
 
     def test_load_from_yaml_file(self):
         file_path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
@@ -76,3 +77,29 @@ class ConfigTest(FileTestCase):
         self.assertEqual(result['client_id'], self.client_id)
         self.assertEqual(result['client_secret'], self.client_secret)
         self.assertEqual(result['refresh_token'], self.refresh_token)
+
+    def test_load_from_env(self):
+        environ = {
+            'GOOGLE_ADS_DEVELOPER_TOKEN': self.developer_token,
+            'GOOGLE_ADS_CLIENT_ID': self.client_id,
+            'GOOGLE_ADS_CLIENT_SECRET': self.client_secret,
+            'GOOGLE_ADS_REFRESH_TOKEN': self.refresh_token,
+            'GOOGLE_ADS_LOGGING': '{"test": true}',
+            'GOOGLE_ADS_ENDPOINT': self.endpoint,
+            'GOOGLE_ADS_LOGIN_CUSTOMER_ID': self.login_customer_id,
+            'GOOGLE_ADS_PATH_TO_PRIVATE_KEY_FILE':
+                self.path_to_private_key_file,
+            'GOOGLE_ADS_DELEGATED_ACCOUNT': self.delegated_account}
+
+        with mock.patch('os.environ', environ):
+            result = config.load_from_env()
+            self.assertEqual(result, {
+                'developer_token': self.developer_token,
+                'client_id': self.client_id,
+                'client_secret': self.client_secret,
+                'refresh_token': self.refresh_token,
+                'logging': {'test': True},
+                'endpoint': self.endpoint,
+                'login_customer_id': self.login_customer_id,
+                'path_to_private_key_file': self.path_to_private_key_file,
+                'delegated_account': self.delegated_account})

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -119,3 +119,32 @@ class ConfigTest(FileTestCase):
             config.validate_dict(config_data)
         except ValueError as ex:
             self.fail('test_validate_dict failed unexpectedly: {}'.format(ex))
+
+    def test_validate_dict_with_invalid_login_cid(self):
+        config_data = {key: 'test' for key in config._REQUIRED_KEYS}
+        config_data['login_customer_id'] = '123-456-5789'
+        self.assertRaises(
+            ValueError,
+            config.validate_dict,
+            config_data)
+
+    def test_validate_dict_with_valid_login_cid(self):
+        config_data = {key: 'test' for key in config._REQUIRED_KEYS}
+        config_data['login_customer_id'] = '1234567893'
+        try:
+            config.validate_dict(config_data)
+        except ValueError as ex:
+            self.fail('test_validate_dict_with_login_cid failed unexpectedly: '
+                      '{}'.format(ex))
+
+    def test_validate_login_customer_id_invalid(self):
+        self.assertRaises(
+            ValueError,
+            config.validate_login_customer_id,
+            '123-456-7890')
+
+    def test_validate_login_customer_id_too_short(self):
+        self.assertRaises(
+            ValueError,
+            config.validate_login_customer_id,
+            '123')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests the configuration helper module."""
+
+import os
+import yaml
+from pyfakefs.fake_filesystem_unittest import TestCase as FileTestCase
+
+from google.ads.google_ads import config
+
+class ConfigTest(FileTestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.developer_token = 'abc123'
+        self.client_id = 'client_id_123456789'
+        self.client_secret = 'client_secret_987654321'
+        self.refresh_token = 'refresh'
+        self.login_customer_id = '1234567890'
+        self.path_to_private_key_file = '/test/path/to/config.json'
+        self.delegated_account = 'delegated@account.com'
+
+
+    def test_load_from_yaml_file(self):
+        file_path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
+        self.fs.create_file(file_path, contents=yaml.safe_dump({
+            'developer_token': self.developer_token,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': self.refresh_token}))
+
+        result = config.load_from_yaml_file()
+
+        self.assertEqual(result['developer_token'], self.developer_token)
+        self.assertEqual(result['client_id'], self.client_id)
+        self.assertEqual(result['client_secret'], self.client_secret)
+        self.assertEqual(result['refresh_token'], self.refresh_token)
+
+    def test_load_from_yaml_file_with_path(self):
+        custom_path = os.path.expanduser('/test/custom/path')
+        file_path = os.path.join(custom_path, 'google-ads.yaml')
+        self.fs.create_file(file_path, contents=yaml.safe_dump({
+            'developer_token': self.developer_token,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': self.refresh_token}))
+
+        result = config.load_from_yaml_file(path=file_path)
+
+        self.assertEqual(result['developer_token'], self.developer_token)
+        self.assertEqual(result['client_id'], self.client_id)
+        self.assertEqual(result['client_secret'], self.client_secret)
+        self.assertEqual(result['refresh_token'], self.refresh_token)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -61,3 +61,18 @@ class ConfigTest(FileTestCase):
         self.assertEqual(result['client_id'], self.client_id)
         self.assertEqual(result['client_secret'], self.client_secret)
         self.assertEqual(result['refresh_token'], self.refresh_token)
+
+    def test_parse_yaml_document_to_dict(self):
+        yaml_doc = ('client_id: {}\n'
+                    'client_secret: {}\n'
+                    'developer_token: {}\n'
+                    'refresh_token: {}\n'.format(
+                        self.client_id, self.client_secret,
+                        self.developer_token, self.refresh_token))
+
+        result = config.parse_yaml_document_to_dict(yaml_doc)
+
+        self.assertEqual(result['developer_token'], self.developer_token)
+        self.assertEqual(result['client_id'], self.client_id)
+        self.assertEqual(result['client_secret'], self.client_secret)
+        self.assertEqual(result['refresh_token'], self.refresh_token)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -191,3 +191,11 @@ class ConfigTest(FileTestCase):
             ValueError,
             config.validate_login_customer_id,
             '123')
+
+    def test_get_oauth2_installed_app_keys(self):
+        self.assertEqual(config.get_oauth2_installed_app_keys(),
+                         config._OAUTH2_INSTALLED_APP_KEYS)
+
+    def test_get_oauth2_service_account_keys(self):
+        self.assertEqual(config.get_oauth2_service_account_keys(),
+                         config._OAUTH2_SERVICE_ACCOUNT_KEYS)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -103,3 +103,19 @@ class ConfigTest(FileTestCase):
                 'login_customer_id': self.login_customer_id,
                 'path_to_private_key_file': self.path_to_private_key_file,
                 'delegated_account': self.delegated_account})
+
+    def test_validate_dict(self):
+        config_data = {'invalid': 'config'}
+
+        self.assertRaises(
+            ValueError,
+            config.validate_dict,
+            config_data
+        )
+
+    def test_validate_dict(self):
+        config_data = {key: 'test' for key in config._REQUIRED_KEYS}
+        try:
+            config.validate_dict(config_data)
+        except ValueError as ex:
+            self.fail('test_validate_dict failed unexpectedly: {}'.format(ex))

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -26,6 +26,9 @@ class OAuth2Tests(TestCase):
         self.client_secret = 'client_secret_987654321'
         self.refresh_token = 'refresh'
         self.token_uri = 'www.tokenuri.com'
+        self.path_to_private_key_file = '/path/to/file'
+        self.subject = 'test@test.com'
+        self.scopes = oauth2._SERVICE_ACCOUNT_SCOPES
 
     def test_get_installed_app_credentials(self):
         mock_credentials = mock.Mock()
@@ -51,3 +54,26 @@ class OAuth2Tests(TestCase):
                 token_uri=self.token_uri)
             mock_request_class.assert_called_once()
             result.refresh.assert_called_once_with(mock_request)
+
+    def test_get_service_account_credentials(self):
+        mock_credentials = mock.Mock()
+        mock_request = mock.Mock()
+        with mock.patch.object(
+            oauth2.ServiceAccountCreds,
+            'from_service_account_file',
+            return_value=mock_credentials
+        ) as mock_initializer, mock.patch.object(
+            oauth2,
+            'Request',
+            return_value = mock_request
+        ) as mock_request_class:
+            result = oauth2.get_service_account_credentials(
+                self.path_to_private_key_file, self.subject)
+
+            mock_initializer.assert_called_once_with(
+                self.path_to_private_key_file,
+                subject=self.subject,
+                scopes=self.scopes)
+            mock_request_class.assert_called_once()
+            result.refresh.assert_called_once_with(mock_request)
+

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -81,14 +81,13 @@ class OAuth2Tests(TestCase):
             'client_id': self.client_id,
             'client_secret': self.client_secret,
             'refresh_token': self.refresh_token}
-        mock_credentials = mock.Mock()
 
         with mock.patch.object(
             oauth2,
             'get_installed_app_credentials',
-            return_value=mock_credentials
+            return_value=None
         ) as mock_initializer:
-            result = oauth2.get_credentials(mock_config)
+            oauth2.get_credentials(mock_config)
             mock_initializer.assert_called_once_with(
                 self.client_id, self.client_secret, self.refresh_token)
 
@@ -102,3 +101,17 @@ class OAuth2Tests(TestCase):
             ValueError,
             oauth2.get_credentials,
             mock_config)
+
+    def test_get_credentials_installed_application(self):
+        mock_config = {
+            'path_to_private_key_file': self.path_to_private_key_file,
+            'delegated_account': self.subject}
+
+        with mock.patch.object(
+            oauth2,
+            'get_service_account_credentials',
+            return_value=None
+        ) as mock_initializer:
+            oauth2.get_credentials(mock_config)
+            mock_initializer.assert_called_once_with(
+                self.path_to_private_key_file, self.subject)

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -91,3 +91,14 @@ class OAuth2Tests(TestCase):
             result = oauth2.get_credentials(mock_config)
             mock_initializer.assert_called_once_with(
                 self.client_id, self.client_secret, self.refresh_token)
+
+    def test_get_credentials_installed_application_bad_config(self):
+        # using a config that is missing the refresh_token key
+        mock_config = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret}
+
+        self.assertRaises(
+            ValueError,
+            oauth2.get_credentials,
+            mock_config)

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the OAuth2 helper module."""
+
+import mock
+from unittest import TestCase
+
+from google.ads.google_ads import oauth2
+
+
+class OAuth2Tests(TestCase):
+
+    def setUp(self):
+        self.client_id = 'client_id_123456789'
+        self.client_secret = 'client_secret_987654321'
+        self.refresh_token = 'refresh'
+        self.token_uri = 'www.tokenuri.com'
+
+    def test_get_installed_app_credentials(self):
+        mock_credentials = mock.Mock()
+        mock_request = mock.Mock()
+        with mock.patch.object(
+            oauth2,
+            'InstalledAppCredentials',
+            return_value=mock_credentials
+        ) as mock_initializer, mock.patch.object(
+            oauth2,
+            'Request',
+            return_value = mock_request
+        ) as mock_request_class:
+            result = oauth2.get_installed_app_credentials(
+                self.client_id, self.client_secret, self.refresh_token,
+                self.token_uri)
+
+            mock_initializer.assert_called_once_with(
+                None,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                refresh_token=self.refresh_token,
+                token_uri=self.token_uri)
+            mock_request_class.assert_called_once()
+            result.refresh.assert_called_once_with(mock_request)

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -25,9 +25,9 @@ class OAuth2Tests(TestCase):
         self.client_id = 'client_id_123456789'
         self.client_secret = 'client_secret_987654321'
         self.refresh_token = 'refresh'
-        self.token_uri = 'www.tokenuri.com'
         self.path_to_private_key_file = '/path/to/file'
         self.subject = 'test@test.com'
+        self.token_uri = oauth2._DEFAULT_TOKEN_URI
         self.scopes = oauth2._SERVICE_ACCOUNT_SCOPES
 
     def test_get_installed_app_credentials(self):
@@ -43,8 +43,7 @@ class OAuth2Tests(TestCase):
             return_value = mock_request
         ) as mock_request_class:
             result = oauth2.get_installed_app_credentials(
-                self.client_id, self.client_secret, self.refresh_token,
-                self.token_uri)
+                self.client_id, self.client_secret, self.refresh_token)
 
             mock_initializer.assert_called_once_with(
                 None,

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -76,3 +76,18 @@ class OAuth2Tests(TestCase):
             mock_request_class.assert_called_once()
             result.refresh.assert_called_once_with(mock_request)
 
+    def test_get_credentials_installed_application(self):
+        mock_config = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': self.refresh_token}
+        mock_credentials = mock.Mock()
+
+        with mock.patch.object(
+            oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials
+        ) as mock_initializer:
+            result = oauth2.get_credentials(mock_config)
+            mock_initializer.assert_called_once_with(
+                self.client_id, self.client_secret, self.refresh_token)


### PR DESCRIPTION
**NOTE**: This change includes breaking changes listed below. It should be released along a major version boundary:

* The `client._get_client_kwargs_from_env` method is removed.
* The `client._get_client_kwargs_from_yaml` method is removed.
* The `client._validate_login_customer_id` method is moved to `google.ads.google_ads.config.validate_login_customer_id`.