### PR TITLE
Increase payload and metadata size defaults for all service transports.

### DIFF
--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -35,11 +35,8 @@ _VALID_API_VERSIONS = ['v1']
 _DEFAULT_VERSION = _VALID_API_VERSIONS[0]
 _REQUEST_ID_KEY = 'request-id'
 _ENV_PREFIX = 'GOOGLE_ADS_'
-_KEYS_ENV_VARIABLES_MAP = {
-    key: _ENV_PREFIX + key.upper() for key in
-    list(_REQUIRED_KEYS) + ['login_customer_id', 'endpoint', 'logging']}
 GRPC_CHANNEL_OPTIONS = [
-    ('grpc.max_metadata_size', 64 * 1024 * 1024),
+    ('grpc.max_metadata_size', 16 * 1024 * 1024),
     ('grpc.max_receive_message_length', 64 * 1024 * 1024)]
 
 class GoogleAdsClient(object):

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -34,6 +34,13 @@ _PROTO_TEMPLATE = '%s_pb2'
 _VALID_API_VERSIONS = ['v1']
 _DEFAULT_VERSION = _VALID_API_VERSIONS[0]
 _REQUEST_ID_KEY = 'request-id'
+_ENV_PREFIX = 'GOOGLE_ADS_'
+_KEYS_ENV_VARIABLES_MAP = {
+    key: _ENV_PREFIX + key.upper() for key in
+    list(_REQUIRED_KEYS) + ['login_customer_id', 'endpoint', 'logging']}
+GRPC_CHANNEL_OPTIONS = [
+    ('grpc.max_metadata_size', 64 * 1024 * 1024),
+    ('grpc.max_receive_message_length', 64 * 1024 * 1024)]
 
 class GoogleAdsClient(object):
     """Google Ads client used to configure settings and fetch services."""
@@ -195,7 +202,8 @@ class GoogleAdsClient(object):
 
         channel = service_transport_class.create_channel(
             address=endpoint,
-            credentials=self.credentials)
+            credentials=self.credentials,
+            options=GRPC_CHANNEL_OPTIONS)
 
         channel = grpc.intercept_channel(
             channel,

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -34,7 +34,6 @@ _PROTO_TEMPLATE = '%s_pb2'
 _VALID_API_VERSIONS = ['v1']
 _DEFAULT_VERSION = _VALID_API_VERSIONS[0]
 _REQUEST_ID_KEY = 'request-id'
-_ENV_PREFIX = 'GOOGLE_ADS_'
 GRPC_CHANNEL_OPTIONS = [
     ('grpc.max_metadata_size', 16 * 1024 * 1024),
     ('grpc.max_receive_message_length', 64 * 1024 * 1024)]

--- a/google/ads/google_ads/v1/services/transports/account_budget_proposal_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/account_budget_proposal_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AccountBudgetProposalServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'account_budget_proposal_service_stub':
-            account_budget_proposal_service_pb2_grpc.
-            AccountBudgetProposalServiceStub(channel),
+            'account_budget_proposal_service_stub': account_budget_proposal_service_pb2_grpc.AccountBudgetProposalServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AccountBudgetProposalServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AccountBudgetProposalServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/account_budget_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/account_budget_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AccountBudgetServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'account_budget_service_stub':
-            account_budget_service_pb2_grpc.AccountBudgetServiceStub(channel),
+            'account_budget_service_stub': account_budget_service_pb2_grpc.AccountBudgetServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AccountBudgetServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AccountBudgetServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_ad_label_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_ad_label_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupAdLabelServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_ad_label_service_stub':
-            ad_group_ad_label_service_pb2_grpc.AdGroupAdLabelServiceStub(
-                channel),
+            'ad_group_ad_label_service_stub': ad_group_ad_label_service_pb2_grpc.AdGroupAdLabelServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupAdLabelServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupAdLabelServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_ad_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_ad_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AdGroupAdServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_ad_service_stub':
-            ad_group_ad_service_pb2_grpc.AdGroupAdServiceStub(channel),
+            'ad_group_ad_service_stub': ad_group_ad_service_pb2_grpc.AdGroupAdServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AdGroupAdServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AdGroupAdServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_audience_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_audience_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupAudienceViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_audience_view_service_stub':
-            ad_group_audience_view_service_pb2_grpc.
-            AdGroupAudienceViewServiceStub(channel),
+            'ad_group_audience_view_service_stub': ad_group_audience_view_service_pb2_grpc.AdGroupAudienceViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupAudienceViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupAudienceViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_bid_modifier_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_bid_modifier_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupBidModifierServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_bid_modifier_service_stub':
-            ad_group_bid_modifier_service_pb2_grpc.
-            AdGroupBidModifierServiceStub(channel),
+            'ad_group_bid_modifier_service_stub': ad_group_bid_modifier_service_pb2_grpc.AdGroupBidModifierServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupBidModifierServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupBidModifierServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_criterion_label_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_criterion_label_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupCriterionLabelServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_criterion_label_service_stub':
-            ad_group_criterion_label_service_pb2_grpc.
-            AdGroupCriterionLabelServiceStub(channel),
+            'ad_group_criterion_label_service_stub': ad_group_criterion_label_service_pb2_grpc.AdGroupCriterionLabelServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupCriterionLabelServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupCriterionLabelServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_criterion_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_criterion_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupCriterionServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_criterion_service_stub':
-            ad_group_criterion_service_pb2_grpc.AdGroupCriterionServiceStub(
-                channel),
+            'ad_group_criterion_service_stub': ad_group_criterion_service_pb2_grpc.AdGroupCriterionServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupCriterionServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupCriterionServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_criterion_simulation_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_criterion_simulation_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupCriterionSimulationServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_criterion_simulation_service_stub':
-            ad_group_criterion_simulation_service_pb2_grpc.
-            AdGroupCriterionSimulationServiceStub(channel),
+            'ad_group_criterion_simulation_service_stub': ad_group_criterion_simulation_service_pb2_grpc.AdGroupCriterionSimulationServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupCriterionSimulationServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupCriterionSimulationServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_extension_setting_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_extension_setting_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupExtensionSettingServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_extension_setting_service_stub':
-            ad_group_extension_setting_service_pb2_grpc.
-            AdGroupExtensionSettingServiceStub(channel),
+            'ad_group_extension_setting_service_stub': ad_group_extension_setting_service_pb2_grpc.AdGroupExtensionSettingServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupExtensionSettingServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupExtensionSettingServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_feed_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_feed_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AdGroupFeedServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_feed_service_stub':
-            ad_group_feed_service_pb2_grpc.AdGroupFeedServiceStub(channel),
+            'ad_group_feed_service_stub': ad_group_feed_service_pb2_grpc.AdGroupFeedServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AdGroupFeedServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AdGroupFeedServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_label_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_label_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AdGroupLabelServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_label_service_stub':
-            ad_group_label_service_pb2_grpc.AdGroupLabelServiceStub(channel),
+            'ad_group_label_service_stub': ad_group_label_service_pb2_grpc.AdGroupLabelServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AdGroupLabelServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AdGroupLabelServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AdGroupServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_service_stub':
-            ad_group_service_pb2_grpc.AdGroupServiceStub(channel),
+            'ad_group_service_stub': ad_group_service_pb2_grpc.AdGroupServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AdGroupServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AdGroupServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_group_simulation_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_group_simulation_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdGroupSimulationServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_group_simulation_service_stub':
-            ad_group_simulation_service_pb2_grpc.AdGroupSimulationServiceStub(
-                channel),
+            'ad_group_simulation_service_stub': ad_group_simulation_service_pb2_grpc.AdGroupSimulationServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdGroupSimulationServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdGroupSimulationServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_parameter_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_parameter_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AdParameterServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_parameter_service_stub':
-            ad_parameter_service_pb2_grpc.AdParameterServiceStub(channel),
+            'ad_parameter_service_stub': ad_parameter_service_pb2_grpc.AdParameterServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AdParameterServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AdParameterServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/ad_schedule_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/ad_schedule_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class AdScheduleViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'ad_schedule_view_service_stub':
-            ad_schedule_view_service_pb2_grpc.AdScheduleViewServiceStub(
-                channel),
+            'ad_schedule_view_service_stub': ad_schedule_view_service_pb2_grpc.AdScheduleViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class AdScheduleViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class AdScheduleViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/age_range_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/age_range_view_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AgeRangeViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'age_range_view_service_stub':
-            age_range_view_service_pb2_grpc.AgeRangeViewServiceStub(channel),
+            'age_range_view_service_stub': age_range_view_service_pb2_grpc.AgeRangeViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AgeRangeViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AgeRangeViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/asset_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/asset_service_grpc_transport.py
@@ -67,14 +67,16 @@ class AssetServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'asset_service_stub':
-            asset_service_pb2_grpc.AssetServiceStub(channel),
+            'asset_service_stub': asset_service_pb2_grpc.AssetServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class AssetServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class AssetServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/bidding_strategy_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/bidding_strategy_service_grpc_transport.py
@@ -67,15 +67,16 @@ class BiddingStrategyServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'bidding_strategy_service_stub':
-            bidding_strategy_service_pb2_grpc.BiddingStrategyServiceStub(
-                channel),
+            'bidding_strategy_service_stub': bidding_strategy_service_pb2_grpc.BiddingStrategyServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class BiddingStrategyServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class BiddingStrategyServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/billing_setup_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/billing_setup_service_grpc_transport.py
@@ -67,14 +67,16 @@ class BillingSetupServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'billing_setup_service_stub':
-            billing_setup_service_pb2_grpc.BillingSetupServiceStub(channel),
+            'billing_setup_service_stub': billing_setup_service_pb2_grpc.BillingSetupServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class BillingSetupServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class BillingSetupServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_audience_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_audience_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignAudienceViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_audience_view_service_stub':
-            campaign_audience_view_service_pb2_grpc.
-            CampaignAudienceViewServiceStub(channel),
+            'campaign_audience_view_service_stub': campaign_audience_view_service_pb2_grpc.CampaignAudienceViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignAudienceViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignAudienceViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_bid_modifier_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_bid_modifier_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignBidModifierServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_bid_modifier_service_stub':
-            campaign_bid_modifier_service_pb2_grpc.
-            CampaignBidModifierServiceStub(channel),
+            'campaign_bid_modifier_service_stub': campaign_bid_modifier_service_pb2_grpc.CampaignBidModifierServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignBidModifierServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignBidModifierServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_budget_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_budget_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignBudgetServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_budget_service_stub':
-            campaign_budget_service_pb2_grpc.CampaignBudgetServiceStub(
-                channel),
+            'campaign_budget_service_stub': campaign_budget_service_pb2_grpc.CampaignBudgetServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignBudgetServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignBudgetServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_criterion_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_criterion_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignCriterionServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_criterion_service_stub':
-            campaign_criterion_service_pb2_grpc.CampaignCriterionServiceStub(
-                channel),
+            'campaign_criterion_service_stub': campaign_criterion_service_pb2_grpc.CampaignCriterionServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignCriterionServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignCriterionServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_criterion_simulation_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_criterion_simulation_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignCriterionSimulationServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_criterion_simulation_service_stub':
-            campaign_criterion_simulation_service_pb2_grpc.
-            CampaignCriterionSimulationServiceStub(channel),
+            'campaign_criterion_simulation_service_stub': campaign_criterion_simulation_service_pb2_grpc.CampaignCriterionSimulationServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignCriterionSimulationServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignCriterionSimulationServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_draft_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_draft_service_grpc_transport.py
@@ -68,20 +68,20 @@ class CampaignDraftServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_draft_service_stub':
-            campaign_draft_service_pb2_grpc.CampaignDraftServiceStub(channel),
+            'campaign_draft_service_stub': campaign_draft_service_pb2_grpc.CampaignDraftServiceStub(channel),
         }
 
         # Because this API includes a method that returns a
         # long-running operation (proto: google.longrunning.Operation),
         # instantiate an LRO client.
-        self._operations_client = google.api_core.operations_v1.OperationsClient(
-            channel)
+        self._operations_client = google.api_core.operations_v1.OperationsClient(channel)
 
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -91,6 +91,8 @@ class CampaignDraftServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -99,6 +101,7 @@ class CampaignDraftServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_experiment_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_experiment_service_grpc_transport.py
@@ -68,21 +68,20 @@ class CampaignExperimentServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_experiment_service_stub':
-            campaign_experiment_service_pb2_grpc.CampaignExperimentServiceStub(
-                channel),
+            'campaign_experiment_service_stub': campaign_experiment_service_pb2_grpc.CampaignExperimentServiceStub(channel),
         }
 
         # Because this API includes a method that returns a
         # long-running operation (proto: google.longrunning.Operation),
         # instantiate an LRO client.
-        self._operations_client = google.api_core.operations_v1.OperationsClient(
-            channel)
+        self._operations_client = google.api_core.operations_v1.OperationsClient(channel)
 
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -92,6 +91,8 @@ class CampaignExperimentServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -100,6 +101,7 @@ class CampaignExperimentServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_extension_setting_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_extension_setting_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignExtensionSettingServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_extension_setting_service_stub':
-            campaign_extension_setting_service_pb2_grpc.
-            CampaignExtensionSettingServiceStub(channel),
+            'campaign_extension_setting_service_stub': campaign_extension_setting_service_pb2_grpc.CampaignExtensionSettingServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignExtensionSettingServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignExtensionSettingServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_feed_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_feed_service_grpc_transport.py
@@ -67,14 +67,16 @@ class CampaignFeedServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_feed_service_stub':
-            campaign_feed_service_pb2_grpc.CampaignFeedServiceStub(channel),
+            'campaign_feed_service_stub': campaign_feed_service_pb2_grpc.CampaignFeedServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class CampaignFeedServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class CampaignFeedServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_label_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_label_service_grpc_transport.py
@@ -67,14 +67,16 @@ class CampaignLabelServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_label_service_stub':
-            campaign_label_service_pb2_grpc.CampaignLabelServiceStub(channel),
+            'campaign_label_service_stub': campaign_label_service_pb2_grpc.CampaignLabelServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class CampaignLabelServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class CampaignLabelServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_service_grpc_transport.py
@@ -67,14 +67,16 @@ class CampaignServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_service_stub':
-            campaign_service_pb2_grpc.CampaignServiceStub(channel),
+            'campaign_service_stub': campaign_service_pb2_grpc.CampaignServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class CampaignServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class CampaignServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/campaign_shared_set_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/campaign_shared_set_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CampaignSharedSetServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'campaign_shared_set_service_stub':
-            campaign_shared_set_service_pb2_grpc.CampaignSharedSetServiceStub(
-                channel),
+            'campaign_shared_set_service_stub': campaign_shared_set_service_pb2_grpc.CampaignSharedSetServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CampaignSharedSetServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CampaignSharedSetServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/carrier_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/carrier_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CarrierConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'carrier_constant_service_stub':
-            carrier_constant_service_pb2_grpc.CarrierConstantServiceStub(
-                channel),
+            'carrier_constant_service_stub': carrier_constant_service_pb2_grpc.CarrierConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CarrierConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CarrierConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/change_status_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/change_status_service_grpc_transport.py
@@ -67,14 +67,16 @@ class ChangeStatusServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'change_status_service_stub':
-            change_status_service_pb2_grpc.ChangeStatusServiceStub(channel),
+            'change_status_service_stub': change_status_service_pb2_grpc.ChangeStatusServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class ChangeStatusServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class ChangeStatusServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/click_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/click_view_service_grpc_transport.py
@@ -67,14 +67,16 @@ class ClickViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'click_view_service_stub':
-            click_view_service_pb2_grpc.ClickViewServiceStub(channel),
+            'click_view_service_stub': click_view_service_pb2_grpc.ClickViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class ClickViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class ClickViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/conversion_action_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/conversion_action_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ConversionActionServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'conversion_action_service_stub':
-            conversion_action_service_pb2_grpc.ConversionActionServiceStub(
-                channel),
+            'conversion_action_service_stub': conversion_action_service_pb2_grpc.ConversionActionServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ConversionActionServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ConversionActionServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/conversion_adjustment_upload_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/conversion_adjustment_upload_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ConversionAdjustmentUploadServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'conversion_adjustment_upload_service_stub':
-            conversion_adjustment_upload_service_pb2_grpc.
-            ConversionAdjustmentUploadServiceStub(channel),
+            'conversion_adjustment_upload_service_stub': conversion_adjustment_upload_service_pb2_grpc.ConversionAdjustmentUploadServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ConversionAdjustmentUploadServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ConversionAdjustmentUploadServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/conversion_upload_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/conversion_upload_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ConversionUploadServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'conversion_upload_service_stub':
-            conversion_upload_service_pb2_grpc.ConversionUploadServiceStub(
-                channel),
+            'conversion_upload_service_stub': conversion_upload_service_pb2_grpc.ConversionUploadServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ConversionUploadServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ConversionUploadServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/custom_interest_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/custom_interest_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CustomInterestServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'custom_interest_service_stub':
-            custom_interest_service_pb2_grpc.CustomInterestServiceStub(
-                channel),
+            'custom_interest_service_stub': custom_interest_service_pb2_grpc.CustomInterestServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CustomInterestServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CustomInterestServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_client_link_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_client_link_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CustomerClientLinkServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_client_link_service_stub':
-            customer_client_link_service_pb2_grpc.
-            CustomerClientLinkServiceStub(channel),
+            'customer_client_link_service_stub': customer_client_link_service_pb2_grpc.CustomerClientLinkServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CustomerClientLinkServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CustomerClientLinkServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_client_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_client_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CustomerClientServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_client_service_stub':
-            customer_client_service_pb2_grpc.CustomerClientServiceStub(
-                channel),
+            'customer_client_service_stub': customer_client_service_pb2_grpc.CustomerClientServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CustomerClientServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CustomerClientServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_extension_setting_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_extension_setting_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CustomerExtensionSettingServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_extension_setting_service_stub':
-            customer_extension_setting_service_pb2_grpc.
-            CustomerExtensionSettingServiceStub(channel),
+            'customer_extension_setting_service_stub': customer_extension_setting_service_pb2_grpc.CustomerExtensionSettingServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CustomerExtensionSettingServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CustomerExtensionSettingServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_feed_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_feed_service_grpc_transport.py
@@ -67,14 +67,16 @@ class CustomerFeedServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_feed_service_stub':
-            customer_feed_service_pb2_grpc.CustomerFeedServiceStub(channel),
+            'customer_feed_service_stub': customer_feed_service_pb2_grpc.CustomerFeedServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class CustomerFeedServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class CustomerFeedServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_label_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_label_service_grpc_transport.py
@@ -67,14 +67,16 @@ class CustomerLabelServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_label_service_stub':
-            customer_label_service_pb2_grpc.CustomerLabelServiceStub(channel),
+            'customer_label_service_stub': customer_label_service_pb2_grpc.CustomerLabelServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class CustomerLabelServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class CustomerLabelServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_manager_link_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_manager_link_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CustomerManagerLinkServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_manager_link_service_stub':
-            customer_manager_link_service_pb2_grpc.
-            CustomerManagerLinkServiceStub(channel),
+            'customer_manager_link_service_stub': customer_manager_link_service_pb2_grpc.CustomerManagerLinkServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CustomerManagerLinkServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CustomerManagerLinkServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_negative_criterion_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_negative_criterion_service_grpc_transport.py
@@ -67,15 +67,16 @@ class CustomerNegativeCriterionServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_negative_criterion_service_stub':
-            customer_negative_criterion_service_pb2_grpc.
-            CustomerNegativeCriterionServiceStub(channel),
+            'customer_negative_criterion_service_stub': customer_negative_criterion_service_pb2_grpc.CustomerNegativeCriterionServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class CustomerNegativeCriterionServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class CustomerNegativeCriterionServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/customer_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/customer_service_grpc_transport.py
@@ -67,14 +67,16 @@ class CustomerServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'customer_service_stub':
-            customer_service_pb2_grpc.CustomerServiceStub(channel),
+            'customer_service_stub': customer_service_pb2_grpc.CustomerServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class CustomerServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class CustomerServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/detail_placement_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/detail_placement_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class DetailPlacementViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'detail_placement_view_service_stub':
-            detail_placement_view_service_pb2_grpc.
-            DetailPlacementViewServiceStub(channel),
+            'detail_placement_view_service_stub': detail_placement_view_service_pb2_grpc.DetailPlacementViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class DetailPlacementViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class DetailPlacementViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/display_keyword_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/display_keyword_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class DisplayKeywordViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'display_keyword_view_service_stub':
-            display_keyword_view_service_pb2_grpc.
-            DisplayKeywordViewServiceStub(channel),
+            'display_keyword_view_service_stub': display_keyword_view_service_pb2_grpc.DisplayKeywordViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class DisplayKeywordViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class DisplayKeywordViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/domain_category_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/domain_category_service_grpc_transport.py
@@ -67,15 +67,16 @@ class DomainCategoryServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'domain_category_service_stub':
-            domain_category_service_pb2_grpc.DomainCategoryServiceStub(
-                channel),
+            'domain_category_service_stub': domain_category_service_pb2_grpc.DomainCategoryServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class DomainCategoryServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class DomainCategoryServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/dynamic_search_ads_search_term_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/dynamic_search_ads_search_term_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class DynamicSearchAdsSearchTermViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'dynamic_search_ads_search_term_view_service_stub':
-            dynamic_search_ads_search_term_view_service_pb2_grpc.
-            DynamicSearchAdsSearchTermViewServiceStub(channel),
+            'dynamic_search_ads_search_term_view_service_stub': dynamic_search_ads_search_term_view_service_pb2_grpc.DynamicSearchAdsSearchTermViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class DynamicSearchAdsSearchTermViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class DynamicSearchAdsSearchTermViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/expanded_landing_page_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/expanded_landing_page_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ExpandedLandingPageViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'expanded_landing_page_view_service_stub':
-            expanded_landing_page_view_service_pb2_grpc.
-            ExpandedLandingPageViewServiceStub(channel),
+            'expanded_landing_page_view_service_stub': expanded_landing_page_view_service_pb2_grpc.ExpandedLandingPageViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ExpandedLandingPageViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ExpandedLandingPageViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/extension_feed_item_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/extension_feed_item_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ExtensionFeedItemServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'extension_feed_item_service_stub':
-            extension_feed_item_service_pb2_grpc.ExtensionFeedItemServiceStub(
-                channel),
+            'extension_feed_item_service_stub': extension_feed_item_service_pb2_grpc.ExtensionFeedItemServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ExtensionFeedItemServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ExtensionFeedItemServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/feed_item_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/feed_item_service_grpc_transport.py
@@ -67,14 +67,16 @@ class FeedItemServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'feed_item_service_stub':
-            feed_item_service_pb2_grpc.FeedItemServiceStub(channel),
+            'feed_item_service_stub': feed_item_service_pb2_grpc.FeedItemServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class FeedItemServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class FeedItemServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/feed_item_target_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/feed_item_target_service_grpc_transport.py
@@ -67,15 +67,16 @@ class FeedItemTargetServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'feed_item_target_service_stub':
-            feed_item_target_service_pb2_grpc.FeedItemTargetServiceStub(
-                channel),
+            'feed_item_target_service_stub': feed_item_target_service_pb2_grpc.FeedItemTargetServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class FeedItemTargetServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class FeedItemTargetServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/feed_mapping_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/feed_mapping_service_grpc_transport.py
@@ -67,14 +67,16 @@ class FeedMappingServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'feed_mapping_service_stub':
-            feed_mapping_service_pb2_grpc.FeedMappingServiceStub(channel),
+            'feed_mapping_service_stub': feed_mapping_service_pb2_grpc.FeedMappingServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class FeedMappingServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class FeedMappingServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/feed_placeholder_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/feed_placeholder_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class FeedPlaceholderViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'feed_placeholder_view_service_stub':
-            feed_placeholder_view_service_pb2_grpc.
-            FeedPlaceholderViewServiceStub(channel),
+            'feed_placeholder_view_service_stub': feed_placeholder_view_service_pb2_grpc.FeedPlaceholderViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class FeedPlaceholderViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class FeedPlaceholderViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/feed_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/feed_service_grpc_transport.py
@@ -67,14 +67,16 @@ class FeedServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'feed_service_stub':
-            feed_service_pb2_grpc.FeedServiceStub(channel),
+            'feed_service_stub': feed_service_pb2_grpc.FeedServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class FeedServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class FeedServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/gender_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/gender_view_service_grpc_transport.py
@@ -67,14 +67,16 @@ class GenderViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'gender_view_service_stub':
-            gender_view_service_pb2_grpc.GenderViewServiceStub(channel),
+            'gender_view_service_stub': gender_view_service_pb2_grpc.GenderViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class GenderViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class GenderViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/geo_target_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/geo_target_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class GeoTargetConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'geo_target_constant_service_stub':
-            geo_target_constant_service_pb2_grpc.GeoTargetConstantServiceStub(
-                channel),
+            'geo_target_constant_service_stub': geo_target_constant_service_pb2_grpc.GeoTargetConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class GeoTargetConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class GeoTargetConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/geographic_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/geographic_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class GeographicViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'geographic_view_service_stub':
-            geographic_view_service_pb2_grpc.GeographicViewServiceStub(
-                channel),
+            'geographic_view_service_stub': geographic_view_service_pb2_grpc.GeographicViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class GeographicViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class GeographicViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/google_ads_field_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/google_ads_field_service_grpc_transport.py
@@ -67,15 +67,16 @@ class GoogleAdsFieldServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'google_ads_field_service_stub':
-            google_ads_field_service_pb2_grpc.GoogleAdsFieldServiceStub(
-                channel),
+            'google_ads_field_service_stub': google_ads_field_service_pb2_grpc.GoogleAdsFieldServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class GoogleAdsFieldServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class GoogleAdsFieldServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/google_ads_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/google_ads_service_grpc_transport.py
@@ -67,14 +67,16 @@ class GoogleAdsServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'google_ads_service_stub':
-            google_ads_service_pb2_grpc.GoogleAdsServiceStub(channel),
+            'google_ads_service_stub': google_ads_service_pb2_grpc.GoogleAdsServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class GoogleAdsServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class GoogleAdsServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/group_placement_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/group_placement_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class GroupPlacementViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'group_placement_view_service_stub':
-            group_placement_view_service_pb2_grpc.
-            GroupPlacementViewServiceStub(channel),
+            'group_placement_view_service_stub': group_placement_view_service_pb2_grpc.GroupPlacementViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class GroupPlacementViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class GroupPlacementViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/hotel_group_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/hotel_group_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class HotelGroupViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'hotel_group_view_service_stub':
-            hotel_group_view_service_pb2_grpc.HotelGroupViewServiceStub(
-                channel),
+            'hotel_group_view_service_stub': hotel_group_view_service_pb2_grpc.HotelGroupViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class HotelGroupViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class HotelGroupViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/hotel_performance_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/hotel_performance_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class HotelPerformanceViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'hotel_performance_view_service_stub':
-            hotel_performance_view_service_pb2_grpc.
-            HotelPerformanceViewServiceStub(channel),
+            'hotel_performance_view_service_stub': hotel_performance_view_service_pb2_grpc.HotelPerformanceViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class HotelPerformanceViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class HotelPerformanceViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_plan_ad_group_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_plan_ad_group_service_grpc_transport.py
@@ -67,15 +67,16 @@ class KeywordPlanAdGroupServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_plan_ad_group_service_stub':
-            keyword_plan_ad_group_service_pb2_grpc.
-            KeywordPlanAdGroupServiceStub(channel),
+            'keyword_plan_ad_group_service_stub': keyword_plan_ad_group_service_pb2_grpc.KeywordPlanAdGroupServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class KeywordPlanAdGroupServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class KeywordPlanAdGroupServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_plan_campaign_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_plan_campaign_service_grpc_transport.py
@@ -67,15 +67,16 @@ class KeywordPlanCampaignServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_plan_campaign_service_stub':
-            keyword_plan_campaign_service_pb2_grpc.
-            KeywordPlanCampaignServiceStub(channel),
+            'keyword_plan_campaign_service_stub': keyword_plan_campaign_service_pb2_grpc.KeywordPlanCampaignServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class KeywordPlanCampaignServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class KeywordPlanCampaignServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_plan_idea_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_plan_idea_service_grpc_transport.py
@@ -67,15 +67,16 @@ class KeywordPlanIdeaServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_plan_idea_service_stub':
-            keyword_plan_idea_service_pb2_grpc.KeywordPlanIdeaServiceStub(
-                channel),
+            'keyword_plan_idea_service_stub': keyword_plan_idea_service_pb2_grpc.KeywordPlanIdeaServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class KeywordPlanIdeaServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class KeywordPlanIdeaServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_plan_keyword_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_plan_keyword_service_grpc_transport.py
@@ -67,15 +67,16 @@ class KeywordPlanKeywordServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_plan_keyword_service_stub':
-            keyword_plan_keyword_service_pb2_grpc.
-            KeywordPlanKeywordServiceStub(channel),
+            'keyword_plan_keyword_service_stub': keyword_plan_keyword_service_pb2_grpc.KeywordPlanKeywordServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class KeywordPlanKeywordServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class KeywordPlanKeywordServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_plan_negative_keyword_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_plan_negative_keyword_service_grpc_transport.py
@@ -67,15 +67,16 @@ class KeywordPlanNegativeKeywordServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_plan_negative_keyword_service_stub':
-            keyword_plan_negative_keyword_service_pb2_grpc.
-            KeywordPlanNegativeKeywordServiceStub(channel),
+            'keyword_plan_negative_keyword_service_stub': keyword_plan_negative_keyword_service_pb2_grpc.KeywordPlanNegativeKeywordServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class KeywordPlanNegativeKeywordServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class KeywordPlanNegativeKeywordServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_plan_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_plan_service_grpc_transport.py
@@ -67,14 +67,16 @@ class KeywordPlanServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_plan_service_stub':
-            keyword_plan_service_pb2_grpc.KeywordPlanServiceStub(channel),
+            'keyword_plan_service_stub': keyword_plan_service_pb2_grpc.KeywordPlanServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class KeywordPlanServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class KeywordPlanServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/keyword_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/keyword_view_service_grpc_transport.py
@@ -67,14 +67,16 @@ class KeywordViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'keyword_view_service_stub':
-            keyword_view_service_pb2_grpc.KeywordViewServiceStub(channel),
+            'keyword_view_service_stub': keyword_view_service_pb2_grpc.KeywordViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class KeywordViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class KeywordViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/label_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/label_service_grpc_transport.py
@@ -67,14 +67,16 @@ class LabelServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'label_service_stub':
-            label_service_pb2_grpc.LabelServiceStub(channel),
+            'label_service_stub': label_service_pb2_grpc.LabelServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class LabelServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class LabelServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/landing_page_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/landing_page_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class LandingPageViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'landing_page_view_service_stub':
-            landing_page_view_service_pb2_grpc.LandingPageViewServiceStub(
-                channel),
+            'landing_page_view_service_stub': landing_page_view_service_pb2_grpc.LandingPageViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class LandingPageViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class LandingPageViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/language_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/language_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class LanguageConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'language_constant_service_stub':
-            language_constant_service_pb2_grpc.LanguageConstantServiceStub(
-                channel),
+            'language_constant_service_stub': language_constant_service_pb2_grpc.LanguageConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class LanguageConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class LanguageConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/location_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/location_view_service_grpc_transport.py
@@ -67,14 +67,16 @@ class LocationViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'location_view_service_stub':
-            location_view_service_pb2_grpc.LocationViewServiceStub(channel),
+            'location_view_service_stub': location_view_service_pb2_grpc.LocationViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class LocationViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class LocationViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/managed_placement_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/managed_placement_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ManagedPlacementViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'managed_placement_view_service_stub':
-            managed_placement_view_service_pb2_grpc.
-            ManagedPlacementViewServiceStub(channel),
+            'managed_placement_view_service_stub': managed_placement_view_service_pb2_grpc.ManagedPlacementViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ManagedPlacementViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ManagedPlacementViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/media_file_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/media_file_service_grpc_transport.py
@@ -67,14 +67,16 @@ class MediaFileServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'media_file_service_stub':
-            media_file_service_pb2_grpc.MediaFileServiceStub(channel),
+            'media_file_service_stub': media_file_service_pb2_grpc.MediaFileServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class MediaFileServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class MediaFileServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/merchant_center_link_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/merchant_center_link_service_grpc_transport.py
@@ -67,15 +67,16 @@ class MerchantCenterLinkServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'merchant_center_link_service_stub':
-            merchant_center_link_service_pb2_grpc.
-            MerchantCenterLinkServiceStub(channel),
+            'merchant_center_link_service_stub': merchant_center_link_service_pb2_grpc.MerchantCenterLinkServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class MerchantCenterLinkServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class MerchantCenterLinkServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/mobile_app_category_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/mobile_app_category_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class MobileAppCategoryConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'mobile_app_category_constant_service_stub':
-            mobile_app_category_constant_service_pb2_grpc.
-            MobileAppCategoryConstantServiceStub(channel),
+            'mobile_app_category_constant_service_stub': mobile_app_category_constant_service_pb2_grpc.MobileAppCategoryConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class MobileAppCategoryConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class MobileAppCategoryConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/mobile_device_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/mobile_device_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class MobileDeviceConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'mobile_device_constant_service_stub':
-            mobile_device_constant_service_pb2_grpc.
-            MobileDeviceConstantServiceStub(channel),
+            'mobile_device_constant_service_stub': mobile_device_constant_service_pb2_grpc.MobileDeviceConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class MobileDeviceConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class MobileDeviceConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/mutate_job_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/mutate_job_service_grpc_transport.py
@@ -68,20 +68,20 @@ class MutateJobServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'mutate_job_service_stub':
-            mutate_job_service_pb2_grpc.MutateJobServiceStub(channel),
+            'mutate_job_service_stub': mutate_job_service_pb2_grpc.MutateJobServiceStub(channel),
         }
 
         # Because this API includes a method that returns a
         # long-running operation (proto: google.longrunning.Operation),
         # instantiate an LRO client.
-        self._operations_client = google.api_core.operations_v1.OperationsClient(
-            channel)
+        self._operations_client = google.api_core.operations_v1.OperationsClient(channel)
 
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -91,6 +91,8 @@ class MutateJobServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -99,6 +101,7 @@ class MutateJobServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/operating_system_version_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/operating_system_version_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class OperatingSystemVersionConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'operating_system_version_constant_service_stub':
-            operating_system_version_constant_service_pb2_grpc.
-            OperatingSystemVersionConstantServiceStub(channel),
+            'operating_system_version_constant_service_stub': operating_system_version_constant_service_pb2_grpc.OperatingSystemVersionConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class OperatingSystemVersionConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class OperatingSystemVersionConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/paid_organic_search_term_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/paid_organic_search_term_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class PaidOrganicSearchTermViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'paid_organic_search_term_view_service_stub':
-            paid_organic_search_term_view_service_pb2_grpc.
-            PaidOrganicSearchTermViewServiceStub(channel),
+            'paid_organic_search_term_view_service_stub': paid_organic_search_term_view_service_pb2_grpc.PaidOrganicSearchTermViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class PaidOrganicSearchTermViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class PaidOrganicSearchTermViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/parental_status_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/parental_status_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ParentalStatusViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'parental_status_view_service_stub':
-            parental_status_view_service_pb2_grpc.
-            ParentalStatusViewServiceStub(channel),
+            'parental_status_view_service_stub': parental_status_view_service_pb2_grpc.ParentalStatusViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ParentalStatusViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ParentalStatusViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/payments_account_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/payments_account_service_grpc_transport.py
@@ -67,15 +67,16 @@ class PaymentsAccountServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'payments_account_service_stub':
-            payments_account_service_pb2_grpc.PaymentsAccountServiceStub(
-                channel),
+            'payments_account_service_stub': payments_account_service_pb2_grpc.PaymentsAccountServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class PaymentsAccountServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class PaymentsAccountServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/product_bidding_category_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/product_bidding_category_constant_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ProductBiddingCategoryConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'product_bidding_category_constant_service_stub':
-            product_bidding_category_constant_service_pb2_grpc.
-            ProductBiddingCategoryConstantServiceStub(channel),
+            'product_bidding_category_constant_service_stub': product_bidding_category_constant_service_pb2_grpc.ProductBiddingCategoryConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ProductBiddingCategoryConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ProductBiddingCategoryConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/product_group_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/product_group_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ProductGroupViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'product_group_view_service_stub':
-            product_group_view_service_pb2_grpc.ProductGroupViewServiceStub(
-                channel),
+            'product_group_view_service_stub': product_group_view_service_pb2_grpc.ProductGroupViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ProductGroupViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ProductGroupViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/recommendation_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/recommendation_service_grpc_transport.py
@@ -67,14 +67,16 @@ class RecommendationServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'recommendation_service_stub':
-            recommendation_service_pb2_grpc.RecommendationServiceStub(channel),
+            'recommendation_service_stub': recommendation_service_pb2_grpc.RecommendationServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class RecommendationServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class RecommendationServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/remarketing_action_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/remarketing_action_service_grpc_transport.py
@@ -67,15 +67,16 @@ class RemarketingActionServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'remarketing_action_service_stub':
-            remarketing_action_service_pb2_grpc.RemarketingActionServiceStub(
-                channel),
+            'remarketing_action_service_stub': remarketing_action_service_pb2_grpc.RemarketingActionServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class RemarketingActionServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class RemarketingActionServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/search_term_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/search_term_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class SearchTermViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'search_term_view_service_stub':
-            search_term_view_service_pb2_grpc.SearchTermViewServiceStub(
-                channel),
+            'search_term_view_service_stub': search_term_view_service_pb2_grpc.SearchTermViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class SearchTermViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class SearchTermViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/shared_criterion_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/shared_criterion_service_grpc_transport.py
@@ -67,15 +67,16 @@ class SharedCriterionServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'shared_criterion_service_stub':
-            shared_criterion_service_pb2_grpc.SharedCriterionServiceStub(
-                channel),
+            'shared_criterion_service_stub': shared_criterion_service_pb2_grpc.SharedCriterionServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class SharedCriterionServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class SharedCriterionServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/shared_set_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/shared_set_service_grpc_transport.py
@@ -67,14 +67,16 @@ class SharedSetServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'shared_set_service_stub':
-            shared_set_service_pb2_grpc.SharedSetServiceStub(channel),
+            'shared_set_service_stub': shared_set_service_pb2_grpc.SharedSetServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class SharedSetServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class SharedSetServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/shopping_performance_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/shopping_performance_view_service_grpc_transport.py
@@ -67,15 +67,16 @@ class ShoppingPerformanceViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'shopping_performance_view_service_stub':
-            shopping_performance_view_service_pb2_grpc.
-            ShoppingPerformanceViewServiceStub(channel),
+            'shopping_performance_view_service_stub': shopping_performance_view_service_pb2_grpc.ShoppingPerformanceViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -85,6 +86,8 @@ class ShoppingPerformanceViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -93,6 +96,7 @@ class ShoppingPerformanceViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/topic_constant_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/topic_constant_service_grpc_transport.py
@@ -67,14 +67,16 @@ class TopicConstantServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'topic_constant_service_stub':
-            topic_constant_service_pb2_grpc.TopicConstantServiceStub(channel),
+            'topic_constant_service_stub': topic_constant_service_pb2_grpc.TopicConstantServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class TopicConstantServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class TopicConstantServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/topic_view_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/topic_view_service_grpc_transport.py
@@ -67,14 +67,16 @@ class TopicViewServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'topic_view_service_stub':
-            topic_view_service_pb2_grpc.TopicViewServiceStub(channel),
+            'topic_view_service_stub': topic_view_service_pb2_grpc.TopicViewServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class TopicViewServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class TopicViewServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/user_interest_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/user_interest_service_grpc_transport.py
@@ -67,14 +67,16 @@ class UserInterestServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'user_interest_service_stub':
-            user_interest_service_pb2_grpc.UserInterestServiceStub(channel),
+            'user_interest_service_stub': user_interest_service_pb2_grpc.UserInterestServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class UserInterestServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class UserInterestServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/user_list_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/user_list_service_grpc_transport.py
@@ -67,14 +67,16 @@ class UserListServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'user_list_service_stub':
-            user_list_service_pb2_grpc.UserListServiceStub(channel),
+            'user_list_service_stub': user_list_service_pb2_grpc.UserListServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class UserListServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class UserListServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/google/ads/google_ads/v1/services/transports/video_service_grpc_transport.py
+++ b/google/ads/google_ads/v1/services/transports/video_service_grpc_transport.py
@@ -67,14 +67,16 @@ class VideoServiceGrpcTransport(object):
         # gRPC uses objects called "stubs" that are bound to the
         # channel and provide a basic method for each RPC.
         self._stubs = {
-            'video_service_stub':
-            video_service_pb2_grpc.VideoServiceStub(channel),
+            'video_service_stub': video_service_pb2_grpc.VideoServiceStub(channel),
         }
 
+
     @classmethod
-    def create_channel(cls,
-                       address='googleads.googleapis.com:443',
-                       credentials=None):
+    def create_channel(
+                cls,
+                address='googleads.googleapis.com:443',
+                credentials=None,
+                **kwargs):
         """Create and return a gRPC channel object.
 
         Args:
@@ -84,6 +86,8 @@ class VideoServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
+            kwargs (dict): Keyword arguments, which are passed to the
+                channel creation.
 
         Returns:
             grpc.Channel: A gRPC channel object.
@@ -92,6 +96,7 @@ class VideoServiceGrpcTransport(object):
             address,
             credentials=credentials,
             scopes=cls._OAUTH_SCOPES,
+            **kwargs
         )
 
     @property

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -370,7 +370,8 @@ class GoogleAdsClientTest(FileTestCase):
             # client.
             client.get_service(service_name)
             mock_create_channel.assert_called_once_with(
-                address=endpoint, credentials=client.credentials)
+                address=endpoint, credentials=client.credentials,
+                options=Client.GRPC_CHANNEL_OPTIONS)
 
     def test_get_service_not_found(self):
         client = self._create_test_client()


### PR DESCRIPTION
All code **not** in the client.py file was generated.