### PR TITLE
Move conversion of login_customer_id to a str to config module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* 2.4.1:
+- Fix bug preventing login_customer_id to be loaded as an int
+
 * 2.4.0:
 - Add utf-8 encoding declaration in generated proto files
 - Add Service Account support

--- a/google/ads/google_ads/__init__.py
+++ b/google/ads/google_ads/__init__.py
@@ -21,4 +21,4 @@ import google.ads.google_ads.errors
 import google.ads.google_ads.util
 
 
-VERSION = '2.4.0'
+VERSION = '2.4.1'

--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -55,14 +55,10 @@ class GoogleAdsClient(object):
         Raises:
             ValueError: If the configuration lacks a required field.
         """
-        login_customer_id = config_data.get('login_customer_id')
-        login_customer_id = str(
-                login_customer_id) if login_customer_id else None
-
         return {'credentials': oauth2.get_credentials(config_data),
                 'developer_token': config_data.get('developer_token'),
                 'endpoint': config_data.get('endpoint'),
-                'login_customer_id': login_customer_id,
+                'login_customer_id': config_data.get('login_customer_id'),
                 'logging_config': config_data.get('logging')}
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
 
 setup(
     name='google-ads',
-    version='2.4.0',
+    version='2.4.1',
     author='Google LLC',
     author_email='googleapis-packages@google.com',
     classifiers=[

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -232,6 +232,40 @@ class GoogleAdsClientTest(FileTestCase):
                 login_customer_id=None,
                 logging_config=None)
 
+    def test_load_from_storage_login_cid_int(self):
+        login_cid = 1234567890
+        config = {
+            'developer_token': self.developer_token,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': self.refresh_token,
+            'login_customer_id': login_cid}
+
+        file_path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
+        self.fs.create_file(file_path, contents=yaml.safe_dump(config))
+        mock_credentials_instance = mock.Mock()
+
+        with mock.patch.object(
+            Client.GoogleAdsClient,
+            '__init__',
+            return_value=None
+        ) as mock_client_init, mock.patch.object(
+            Client.oauth2,
+            'get_installed_app_credentials',
+            return_value=mock_credentials_instance
+        ) as mock_credentials:
+            Client.GoogleAdsClient.load_from_storage()
+            mock_credentials.assert_called_once_with(
+                config.get('client_id'),
+                config.get('client_secret'),
+                config.get('refresh_token'))
+            mock_client_init.assert_called_once_with(
+                credentials=mock_credentials_instance,
+                developer_token=self.developer_token,
+                endpoint=None,
+                login_customer_id=str(login_cid),
+                logging_config=None)
+
     def test_load_from_storage_custom_path(self):
         config = {
             'developer_token': self.developer_token,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -75,6 +75,23 @@ class ConfigTest(FileTestCase):
         self.assertEqual(result['client_secret'], self.client_secret)
         self.assertEqual(result['refresh_token'], self.refresh_token)
 
+    def test_load_from_yaml_file_login_cid_int(self):
+        login_cid_int = 1234567890
+        file_path = os.path.join(os.path.expanduser('~'), 'google-ads.yaml')
+        self.fs.create_file(file_path, contents=yaml.safe_dump({
+            'login_customer_id': login_cid_int,
+            'developer_token': self.developer_token,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': self.refresh_token}))
+
+        result = config.load_from_yaml_file()
+
+        self.assertEqual(result['developer_token'], self.developer_token)
+        self.assertEqual(result['client_id'], self.client_id)
+        self.assertEqual(result['client_secret'], self.client_secret)
+        self.assertEqual(result['refresh_token'], self.refresh_token)
+
     def test_parse_yaml_document_to_dict(self):
         yaml_doc = ('client_id: {}\n'
                     'client_secret: {}\n'
@@ -199,3 +216,19 @@ class ConfigTest(FileTestCase):
     def test_get_oauth2_service_account_keys(self):
         self.assertEqual(config.get_oauth2_service_account_keys(),
                          config._OAUTH2_SERVICE_ACCOUNT_KEYS)
+
+    def test_convert_login_customer_id_to_str_with_int(self):
+        config_data = {'login_customer_id': 1234567890}
+        expected = {'login_customer_id': '1234567890'}
+        self.assertEqual(config.convert_login_customer_id_to_str(config_data),
+                         expected)
+
+    def test_parse_login_customer_id_with_str(self):
+        config_data = {'login_customer_id': '1234567890'}
+        self.assertEqual(config.convert_login_customer_id_to_str(config_data),
+                         config_data)
+
+    def test_parse_login_customer_id_with_none(self):
+        config_data = {'not_login_customer_id': 1234567890}
+        self.assertEqual(config.convert_login_customer_id_to_str(config_data),
+                         config_data)


### PR DESCRIPTION
Previously the `login_customer_id` config value was converted to a str in the client module [here](https://github.com/googleads/google-ads-python/blob/master/google/ads/google_ads/client.py#L59). Since validation of login customer id was moved to the new config module validation occurred before this step, and IDs that were of type `int` raised an error because they have no method `isdigit`.

This change adds a mechanism to the config module that parses config values, converting `login_customer_id` to a string before validation occurs.