### PR TITLE
Regenerate customer_service for v2

### DIFF
--- a/google/ads/google_ads/v2/services/customer_service_client.py
+++ b/google/ads/google_ads/v2/services/customer_service_client.py
@@ -333,8 +333,8 @@ class CustomerServiceClient(object):
             self,
             customer_id,
             customer_client,
-            email_address,
-            access_role,
+            email_address=None,
+            access_role=None,
             retry=google.api_core.gapic_v1.method.DEFAULT,
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             metadata=None):


### PR DESCRIPTION
When this was initially generated for v2 `email_address` and `access_role` were erroneously marked as required. A fresh regeneration marks them as optional as is expected.'

Fixes: https://github.com/googleads/google-ads-python/issues/158