### PR TITLE
removed using list[] directly as default args in GoogleAdsClient

### DIFF
--- a/google/ads/google_ads/client.py
+++ b/google/ads/google_ads/client.py
@@ -194,7 +194,7 @@ class GoogleAdsClient(object):
         self.endpoint = endpoint
         self.login_customer_id = login_customer_id
 
-    def get_service(self, name, version=_DEFAULT_VERSION, interceptors=[]):
+    def get_service(self, name, version=_DEFAULT_VERSION, interceptors=None):
         """Returns a service client instance for the specified service_name.
 
         Args:
@@ -214,6 +214,7 @@ class GoogleAdsClient(object):
             AttributeError: If the specified name doesn't exist.
         """
         api_module = self._get_api_services_by_version(version)
+        interceptors = interceptors or []
 
         try:
             service_client = getattr(api_module,


### PR DESCRIPTION
Python’s default arguments are evaluated once when the function is defined, not each time the function is called. This means that if you use a mutable default argument and mutate it, you will and have mutated that object for all future calls to the function as well.