### PR TITLE
Use get_message helper when exporting dependent types for v2

### DIFF
--- a/google/ads/google_ads/v2/types.py
+++ b/google/ads/google_ads/v2/types.py
@@ -1635,7 +1635,7 @@ DEPENDENT_MODULE_LIST = [
 
 def _get_class_from_module(module_name):
     module = importlib.import_module(module_name)
-    for class_name, _ in get_messages(module).items(): # from inspect module
+    for class_name in get_messages(module).keys(): # from inspect module
         yield class_name
 
 def _populate_dependent_classes(module_list = DEPENDENT_MODULE_LIST):

--- a/google/ads/google_ads/v2/types.py
+++ b/google/ads/google_ads/v2/types.py
@@ -16,9 +16,7 @@
 
 
 import importlib
-import re
 import sys
-from inspect import getmembers, isclass
 from itertools import chain
 
 from google.api_core.protobuf_helpers import get_messages
@@ -1637,7 +1635,7 @@ DEPENDENT_MODULE_LIST = [
 
 def _get_class_from_module(module_name):
     module = importlib.import_module(module_name)
-    for class_name, _ in getmembers(module, isclass): # from inspect module
+    for class_name, _ in get_messages(module).items(): # from inspect module
         yield class_name
 
 def _populate_dependent_classes(module_list = DEPENDENT_MODULE_LIST):


### PR DESCRIPTION
Retrieving class names using `getmembers` on pb2 modules returns _all_ classes, including some which are not protobuf message classes, (namely `google.longrunning.operations_pb2.OperationsStub`). Since we use types.py to consolidate protobuf message classes for easy access by the `client.get_type` method we want to use `get_messages` to limit the exposed classes to just protobuf message classes. 