### PR TITLE
Update retrieval of customer ID

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* 5.0.4
+- Enable logging interceptor to retrieve customer ID from resource_name.
+
 * 5.0.3
 - Fix bug in generated init files preventing import *.
 

--- a/google/ads/google_ads/interceptors/logging_interceptor.py
+++ b/google/ads/google_ads/interceptors/logging_interceptor.py
@@ -122,8 +122,6 @@ class LoggingInterceptor(Interceptor, UnaryUnaryClientInterceptor,
         elif hasattr(request, 'resource_name'):
             return getattr(request, 'resource_name').split('/')[-1]
 
-        return 'N/A'
-
     def _parse_exception_to_str(self, exception):
         """Parses response exception object to str for logging.
 

--- a/google/ads/google_ads/interceptors/logging_interceptor.py
+++ b/google/ads/google_ads/interceptors/logging_interceptor.py
@@ -117,7 +117,12 @@ class LoggingInterceptor(Interceptor, UnaryUnaryClientInterceptor,
         Args:
             request: An instance of a request proto message.
         """
-        return getattr(request, 'customer_id', None)
+        if hasattr(request, 'customer_id'):
+            return getattr(request, 'customer_id')
+        elif hasattr(request, 'resource_name'):
+            return getattr(request, 'resource_name').split('/')[-1]
+
+        return 'N/A'
 
     def _parse_exception_to_str(self, exception):
         """Parses response exception object to str for logging.

--- a/google/ads/google_ads/interceptors/logging_interceptor.py
+++ b/google/ads/google_ads/interceptors/logging_interceptor.py
@@ -120,7 +120,10 @@ class LoggingInterceptor(Interceptor, UnaryUnaryClientInterceptor,
         if hasattr(request, 'customer_id'):
             return getattr(request, 'customer_id')
         elif hasattr(request, 'resource_name'):
-            return getattr(request, 'resource_name').split('/')[-1]
+            resource_name = getattr(request, 'resource_name')
+            segments = resource_name.split('/')
+            if segments[0] == 'customers':
+                return segments[1]
 
     def _parse_exception_to_str(self, exception):
         """Parses response exception object to str for logging.

--- a/google/ads/google_ads/interceptors/logging_interceptor.py
+++ b/google/ads/google_ads/interceptors/logging_interceptor.py
@@ -124,6 +124,8 @@ class LoggingInterceptor(Interceptor, UnaryUnaryClientInterceptor,
             segments = resource_name.split('/')
             if segments[0] == 'customers':
                 return segments[1]
+        else:
+            return None
 
     def _parse_exception_to_str(self, exception):
         """Parses response exception object to str for logging.

--- a/tests/interceptors/logging_interceptor_test.py
+++ b/tests/interceptors/logging_interceptor_test.py
@@ -22,6 +22,7 @@ import mock
 
 from google.ads.google_ads import client as Client
 from google.ads.google_ads.interceptors import LoggingInterceptor
+from google.ads.google_ads.v3.proto.services import customer_service_pb2
 
 default_version = Client._DEFAULT_VERSION
 
@@ -530,3 +531,25 @@ class LoggingInterceptorTest(TestCase):
             interceptor = self._create_test_interceptor()
             result = interceptor._get_fault_message(mock_exception)
             self.assertEqual(result, self._MOCK_TRANSPORT_ERROR_MESSAGE)
+
+    def test_get_customer_id_not_present(self):
+        """Retrieves a customer_id from a request object or 'N/A' otherwise."""
+        mock_request = {}
+        interceptor = self._create_test_interceptor()
+        self.assertEqual(interceptor._get_customer_id(mock_request), 'N/A')
+
+    def test_get_customer_id(self):
+        """Retrieves a customer_id from a request object."""
+        mock_request = self._get_mock_request()
+        interceptor = self._create_test_interceptor()
+        self.assertEqual(interceptor._get_customer_id(mock_request),
+                         self._MOCK_CUSTOMER_ID)
+
+    def test_get_customer_id_from_resource_name(self):
+        """Retrieves a customer_id from a request object via resource name."""
+        resource_name = f'customer/{self._MOCK_CUSTOMER_ID}'
+        mock_request = customer_service_pb2.GetCustomerRequest(
+            resource_name=resource_name)
+        interceptor = self._create_test_interceptor()
+        self.assertEqual(interceptor._get_customer_id(mock_request),
+                         self._MOCK_CUSTOMER_ID)

--- a/tests/interceptors/logging_interceptor_test.py
+++ b/tests/interceptors/logging_interceptor_test.py
@@ -536,7 +536,7 @@ class LoggingInterceptorTest(TestCase):
         """Retrieves a customer_id from a request object or 'N/A' otherwise."""
         mock_request = {}
         interceptor = self._create_test_interceptor()
-        self.assertEqual(interceptor._get_customer_id(mock_request), 'N/A')
+        self.assertEqual(interceptor._get_customer_id(mock_request), None)
 
     def test_get_customer_id(self):
         """Retrieves a customer_id from a request object."""

--- a/tests/interceptors/logging_interceptor_test.py
+++ b/tests/interceptors/logging_interceptor_test.py
@@ -533,7 +533,7 @@ class LoggingInterceptorTest(TestCase):
             self.assertEqual(result, self._MOCK_TRANSPORT_ERROR_MESSAGE)
 
     def test_get_customer_id_not_present(self):
-        """Retrieves a customer_id from a request object or 'N/A' otherwise."""
+        """Returns None if request has no customer_id or resource_name."""
         mock_request = {}
         interceptor = self._create_test_interceptor()
         self.assertEqual(interceptor._get_customer_id(mock_request), None)
@@ -546,10 +546,18 @@ class LoggingInterceptorTest(TestCase):
                          self._MOCK_CUSTOMER_ID)
 
     def test_get_customer_id_from_resource_name(self):
-        """Retrieves a customer_id from a request object via resource name."""
-        resource_name = f'customer/{self._MOCK_CUSTOMER_ID}'
+        """Retrieves a customer_id from a request object via resource_name."""
+        resource_name = f'customers/{self._MOCK_CUSTOMER_ID}'
         mock_request = customer_service_pb2.GetCustomerRequest(
             resource_name=resource_name)
         interceptor = self._create_test_interceptor()
         self.assertEqual(interceptor._get_customer_id(mock_request),
                          self._MOCK_CUSTOMER_ID)
+
+    def test_get_customer_id_from_invalid_resource_name(self):
+        """Returns None for a resource_name not starting with 'customers'."""
+        resource_name = f'languageConstants/{self._MOCK_CUSTOMER_ID}'
+        mock_request = customer_service_pb2.GetCustomerRequest(
+            resource_name=resource_name)
+        interceptor = self._create_test_interceptor()
+        self.assertEqual(interceptor._get_customer_id(mock_request), None)


### PR DESCRIPTION
The `GetCustomerRequest` object sends a resource name instead of a customer ID so this updates the logging interceptor slightly to parse the customer ID from it. 

Mirroring change made in Ruby here: https://github.com/googleads/google-ads-ruby/pull/29/files