### PR TITLE
Print raw trailing metadata for responses

### DIFF
--- a/google/ads/google_ads/interceptors/exception_interceptor.py
+++ b/google/ads/google_ads/interceptors/exception_interceptor.py
@@ -193,4 +193,5 @@ class ExceptionInterceptor(Interceptor, UnaryUnaryClientInterceptor,
                 status code of INTERNAL or RESOURCE_EXHAUSTED.
         """
         response = continuation(client_call_details, request)
+        print(f'Trailing Metadata {response.trailing_metadata()}')
         return _UnaryStreamWrapper(response, self._handle_grpc_failure)


### PR DESCRIPTION
This is an example of how to log the raw error message from failed API requests that may be printed as `status = StatusCode.INTERNAL`