### PR TITLE
Fix syntax error in add_sitelink.py example

### DIFF
--- a/examples/extensions/add_sitelinks.py
+++ b/examples/extensions/add_sitelinks.py
@@ -212,7 +212,7 @@ def _get_thanksgiving_string_date_range():
 
     if start_dt < now:
         # Move start_dt to next year if the current date is past November 20th.
-        start_dt.year += 1
+        start_dt = start_dt + datetime.timedelta(days=365)
 
     end_dt = datetime.datetime(start_dt.year, 11, 27, 23, 59, 59)
 


### PR DESCRIPTION
This line wasn't tested previously because it only executes if the current date is after Nov. 20.