### PR TITLE
Fix issues in add_hotel_listing_group_tree example

### DIFF
--- a/examples/hotel_ads/add_hotel_listing_group_tree.py
+++ b/examples/hotel_ads/add_hotel_listing_group_tree.py
@@ -245,6 +245,12 @@ def _add_level1_nodes(
     other_hotels_listing_dimension_info = client.get_type(
         "ListingDimensionInfo", version="v6"
     )
+    # This is necessary to set "hotel_class" as the oneof field on the
+    # ListingDimentionInfo object without specifying the optional
+    # hotel_class.value field.
+    other_hotels_listing_dimension_info.hotel_class.CopyFrom(
+        client.get_type("HotelClassInfo", version="v6")
+    )
 
     # Create listing group info for other hotel classes as a SUBDIVISION node,
     # which will be used as a parent node for children nodes of the next level.
@@ -350,6 +356,12 @@ def _add_level2_nodes(
     # Create hotel class info and dimension info for hotels in other regions.
     other_hotel_regions_listing_dimension_info = client.get_type(
         "ListingDimensionInfo", version="v6"
+    )
+    # This is necessary to set "hotel_country_region" as the oneof field on the
+    # ListingDimentionInfo object without specifying the optional
+    # hotel_country_region.country_region_criterion field.
+    other_hotel_regions_listing_dimension_info.hotel_country_region.CopyFrom(
+        client.get_type("HotelCountryRegionInfo", version="v6")
     )
 
     # Create listing group info for hotels in other regions as a UNIT node.

--- a/examples/hotel_ads/add_hotel_listing_group_tree.py
+++ b/examples/hotel_ads/add_hotel_listing_group_tree.py
@@ -245,9 +245,8 @@ def _add_level1_nodes(
     other_hotels_listing_dimension_info = client.get_type(
         "ListingDimensionInfo", version="v6"
     )
-    # This is necessary to set "hotel_class" as the oneof field on the
-    # ListingDimentionInfo object without specifying the optional
-    # hotel_class.value field.
+    # Set "hotel_class" as the oneof field on the ListingDimentionInfo object
+    # without specifying the optional hotel_class.value field.
     other_hotels_listing_dimension_info.hotel_class.CopyFrom(
         client.get_type("HotelClassInfo", version="v6")
     )
@@ -357,8 +356,8 @@ def _add_level2_nodes(
     other_hotel_regions_listing_dimension_info = client.get_type(
         "ListingDimensionInfo", version="v6"
     )
-    # This is necessary to set "hotel_country_region" as the oneof field on the
-    # ListingDimentionInfo object without specifying the optional
+    # Set "hotel_country_region" as the oneof field on the ListingDimentionInfo
+    # object without specifying the optional
     # hotel_country_region.country_region_criterion field.
     other_hotel_regions_listing_dimension_info.hotel_country_region.CopyFrom(
         client.get_type("HotelCountryRegionInfo", version="v6")


### PR DESCRIPTION
This example wasn't correctly creating entities to cover the "others" case, as is done [here](https://github.com/googleads/google-ads-php/blob/master/examples/HotelAds/AddHotelListingGroupTree.php#L260) in the PHP example.