### PR TITLE
Fixes #364: Treat customer_client.id as str

### DIFF
--- a/examples/account_management/get_account_hierarchy.py
+++ b/examples/account_management/get_account_hierarchy.py
@@ -120,7 +120,7 @@ def main(client, login_customer_id=None):
                         # prevent visiting the same customer many times, we
                         # need to check if it's already in the Dictionary.
                         if (
-                            customer_client.id
+                            str(customer_client.id)
                             not in customer_ids_to_child_accounts
                             and customer_client.level == 1
                         ):


### PR DESCRIPTION
As described in #364, 

Currently script runs into a `TypeError` for trying to find `customer_client.id` of type `<class 'google.protobuf.wrappers_pb2.Int64Value'>` in the keys of a dictionary.  Keys must be strings so the following if block runs into an error:

```
if (
    customer_client.id
    not in customer_ids_to_child_accounts
    and customer_client.level == 1
)
```

`customer_client.id` must be within a  **str**. Actually source code got it right at [line 173](https://github.com/googleads/google-ads-python/blob/d90d9e9aadfa3b81a95110f806547010c0e0824d/examples/account_management/get_account_hierarchy.py#L173)