### PR TITLE
Fix bug breaking Python 3.6 compatibility.

### DIFF
--- a/google/ads/googleads/v5/__init__.py
+++ b/google/ads/googleads/v5/__init__.py
@@ -20,8 +20,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError("This module requires Python 3.7 or later.")
+if sys.version_info < (3, 6):
+    raise ImportError("This module requires Python 3.6 or later.")
 
 
 _lazy_type_to_package_map = {
@@ -1491,3 +1491,9 @@ def __getattr__(name):  # Requires Python >= 3.7
 
 def __dir__():
     return globals().get("__all__") or __getattr__("__all__")
+
+
+if not sys.version_info >= (3, 7):
+    from pep562 import Pep562
+
+    Pep562(__name__)

--- a/google/ads/googleads/v6/__init__.py
+++ b/google/ads/googleads/v6/__init__.py
@@ -20,8 +20,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError("This module requires Python 3.7 or later.")
+if sys.version_info < (3, 6):
+    raise ImportError("This module requires Python 3.6 or later.")
 
 
 _lazy_type_to_package_map = {
@@ -1586,3 +1586,9 @@ def __getattr__(name):  # Requires Python >= 3.7
 
 def __dir__():
     return globals().get("__all__") or __getattr__("__all__")
+
+
+if not sys.version_info >= (3, 7):
+    from pep562 import Pep562
+
+    Pep562(__name__)

--- a/google/ads/googleads/v7/__init__.py
+++ b/google/ads/googleads/v7/__init__.py
@@ -17,8 +17,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError("This module requires Python 3.7 or later.")
+if sys.version_info < (3, 6):
+    raise ImportError("This module requires Python 3.6 or later.")
 
 
 _lazy_type_to_package_map = {
@@ -1656,3 +1656,9 @@ def __getattr__(name):  # Requires Python >= 3.7
 
 def __dir__():
     return globals().get("__all__") or __getattr__("__all__")
+
+
+if not sys.version_info >= (3, 7):
+    from pep562 import Pep562
+
+    Pep562(__name__)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session
+@nox.session(python=["3.6", "3.7"])
 def tests(session):
     session.install(".")
     # modules for testing

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,14 @@ from setuptools import setup, find_packages
 import io
 
 install_requires = [
+    "dataclasses >= 0.6, < 1.0.0",
     "google-auth-oauthlib >= 0.3.0, < 1.0.0",
     "google-api-core >= 1.21.0, < 2.0.0",
     "googleapis-common-protos >= 1.5.8, < 2.0.0",
     "grpcio >= 1.33.2, < 2.0.0",
     "proto-plus >= 1.18.0, < 2.0.0",
     "PyYAML >= 5.1, < 6.0",
-    "setuptools>=40.3.0",
+    "setuptools >= 40.3.0",
     "pep562 >= 1.0, < 2.0",
     "nox == 2020.12.31",
 ]


### PR DESCRIPTION
* Update unit tests to run in Python 3.6 and 3.7
* Add `dataclasses` dependency for Python 3.6 compatibility.
* Update __init__.py files where __getattr__ is used at the module level.