### PR TITLE
Fix package name in base transport.

### DIFF
--- a/google/ads/googleads/v6/services/services/account_budget_proposal_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/account_budget_proposal_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/account_budget_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/account_budget_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import account_budget_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/account_link_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/account_link_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import account_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_ad_asset_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_ad_asset_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_ad_label_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_ad_label_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_ad_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_ad_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_ad_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_ad_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_audience_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_audience_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_bid_modifier_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_bid_modifier_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_bid_modifier_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_criterion_label_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_criterion_label_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_criterion_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_criterion_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_criterion_simulation_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_criterion_simulation_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_extension_setting_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_feed_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_feed_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_label_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_label_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_group_simulation_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_group_simulation_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_group_simulation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_parameter_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_parameter_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_parameter_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_schedule_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_schedule_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_schedule_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/ad_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/ad_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import ad_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/age_range_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/age_range_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import age_range_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/asset_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/asset_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/batch_job_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/batch_job_service/transports/base.py
@@ -32,9 +32,7 @@ from google.longrunning import operations_pb2 as operations  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/bidding_strategy_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/bidding_strategy_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import bidding_strategy_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/billing_setup_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/billing_setup_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import billing_setup_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_asset_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_asset_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_audience_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_audience_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_bid_modifier_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_bid_modifier_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_bid_modifier_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_budget_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_budget_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_budget_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_criterion_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_criterion_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_criterion_simulation_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_criterion_simulation_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_draft_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_draft_service/transports/base.py
@@ -32,9 +32,7 @@ from google.longrunning import operations_pb2 as operations  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_experiment_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_experiment_service/transports/base.py
@@ -33,9 +33,7 @@ from google.protobuf import empty_pb2 as empty  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_extension_setting_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_feed_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_feed_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_label_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_label_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/campaign_shared_set_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/campaign_shared_set_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import campaign_shared_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/carrier_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/carrier_constant_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import carrier_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/change_status_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/change_status_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import change_status_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/click_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/click_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import click_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/combined_audience_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/combined_audience_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import combined_audience_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/conversion_action_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/conversion_action_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import conversion_action_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/conversion_adjustment_upload_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/conversion_adjustment_upload_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/conversion_upload_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/conversion_upload_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import conversion_upload_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/currency_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/currency_constant_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import currency_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/custom_audience_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/custom_audience_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import custom_audience_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/custom_interest_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/custom_interest_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import custom_interest_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_client_link_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_client_link_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_client_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_client_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_client_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_client_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_extension_setting_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_feed_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_feed_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_label_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_label_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_manager_link_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_manager_link_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_manager_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_negative_criterion_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_negative_criterion_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_user_access_invitation_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_user_access_invitation_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/customer_user_access_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/customer_user_access_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import customer_user_access_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/detail_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/detail_placement_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import detail_placement_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/display_keyword_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/display_keyword_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import display_keyword_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/distance_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/distance_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import distance_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/domain_category_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/domain_category_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import domain_category_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/dynamic_search_ads_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/dynamic_search_ads_search_term_view_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/expanded_landing_page_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/expanded_landing_page_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/extension_feed_item_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/extension_feed_item_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import extension_feed_item_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_item_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_item_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_item_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_item_set_link_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_item_set_link_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_item_set_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_item_set_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_item_set_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_item_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_item_target_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_item_target_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_item_target_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_mapping_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_mapping_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_mapping_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_placeholder_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_placeholder_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_placeholder_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/feed_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/feed_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/gender_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/gender_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import gender_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/geo_target_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/geo_target_constant_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import geo_target_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/geographic_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/geographic_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import geographic_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/google_ads_field_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/google_ads_field_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import google_ads_field_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/google_ads_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/google_ads_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import google_ads_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/group_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/group_placement_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import group_placement_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/hotel_group_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/hotel_group_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import hotel_group_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/hotel_performance_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/hotel_performance_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/income_range_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/income_range_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import income_range_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/invoice_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/invoice_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import invoice_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_plan_ad_group_keyword_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_plan_ad_group_keyword_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_plan_ad_group_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_plan_ad_group_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import keyword_plan_ad_group_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_plan_campaign_keyword_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_plan_campaign_keyword_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_plan_campaign_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_plan_campaign_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import keyword_plan_campaign_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_plan_idea_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_plan_idea_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import keyword_plan_idea_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_plan_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_plan_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import keyword_plan_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/keyword_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/keyword_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import keyword_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/label_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/label_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/landing_page_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/landing_page_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import landing_page_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/language_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/language_constant_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import language_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/location_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/location_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import location_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/managed_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/managed_placement_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/media_file_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/media_file_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import media_file_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/merchant_center_link_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/merchant_center_link_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import merchant_center_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/mobile_app_category_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/mobile_app_category_constant_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/mobile_device_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/mobile_device_constant_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/offline_user_data_job_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/offline_user_data_job_service/transports/base.py
@@ -32,9 +32,7 @@ from google.longrunning import operations_pb2 as operations  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/operating_system_version_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/operating_system_version_constant_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/paid_organic_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/paid_organic_search_term_view_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/parental_status_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/parental_status_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import parental_status_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/payments_account_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/payments_account_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import payments_account_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/product_bidding_category_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/product_bidding_category_constant_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/product_group_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/product_group_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import product_group_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/reach_plan_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/reach_plan_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import reach_plan_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/recommendation_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/recommendation_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import recommendation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/remarketing_action_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/remarketing_action_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import remarketing_action_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/search_term_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import search_term_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/shared_criterion_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/shared_criterion_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import shared_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/shared_set_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/shared_set_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import shared_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/shopping_performance_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/shopping_performance_view_service/transports/base.py
@@ -32,9 +32,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/third_party_app_analytics_link_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/third_party_app_analytics_link_service/transports/base.py
@@ -34,9 +34,7 @@ from google.ads.googleads.v6.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/topic_constant_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/topic_constant_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import topic_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/topic_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/topic_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import topic_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/user_data_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/user_data_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v6.services.types import user_data_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/user_interest_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/user_interest_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import user_interest_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/user_list_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/user_list_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import user_list_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/user_location_view_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/user_location_view_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import user_location_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v6/services/services/video_service/transports/base.py
+++ b/google/ads/googleads/v6/services/services/video_service/transports/base.py
@@ -30,9 +30,7 @@ from google.ads.googleads.v6.services.types import video_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/account_budget_proposal_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/account_budget_proposal_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/account_budget_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/account_budget_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import account_budget_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/account_link_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/account_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import account_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_ad_asset_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_ad_asset_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_ad_label_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_ad_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_ad_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_ad_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_ad_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_ad_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_asset_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_audience_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_audience_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_bid_modifier_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_bid_modifier_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_bid_modifier_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_criterion_label_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_criterion_label_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_criterion_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_criterion_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_criterion_simulation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_criterion_simulation_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_extension_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_feed_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_label_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_group_simulation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_group_simulation_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_group_simulation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_parameter_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_parameter_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_parameter_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_schedule_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_schedule_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_schedule_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/ad_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/ad_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import ad_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/age_range_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/age_range_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import age_range_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/asset_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/batch_job_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/batch_job_service/transports/base.py
@@ -29,9 +29,7 @@ from google.longrunning import operations_pb2 as operations  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/bidding_strategy_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/bidding_strategy_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import bidding_strategy_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/bidding_strategy_simulation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/bidding_strategy_simulation_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/billing_setup_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/billing_setup_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import billing_setup_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_asset_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_audience_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_audience_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_bid_modifier_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_bid_modifier_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_bid_modifier_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_budget_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_budget_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_budget_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_criterion_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_criterion_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_criterion_simulation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_criterion_simulation_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_draft_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_draft_service/transports/base.py
@@ -29,9 +29,7 @@ from google.longrunning import operations_pb2 as operations  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_experiment_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_experiment_service/transports/base.py
@@ -30,9 +30,7 @@ from google.protobuf import empty_pb2 as empty  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_extension_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_feed_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_label_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_shared_set_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_shared_set_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_shared_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/campaign_simulation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/campaign_simulation_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import campaign_simulation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/carrier_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/carrier_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import carrier_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/change_status_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/change_status_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import change_status_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/click_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/click_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import click_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/combined_audience_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/combined_audience_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import combined_audience_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/conversion_action_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/conversion_action_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import conversion_action_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/conversion_adjustment_upload_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/conversion_adjustment_upload_service/transports/base.py
@@ -28,9 +28,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/conversion_custom_variable_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/conversion_custom_variable_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/conversion_upload_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/conversion_upload_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import conversion_upload_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/currency_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/currency_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import currency_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/custom_audience_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/custom_audience_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import custom_audience_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/custom_interest_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/custom_interest_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import custom_interest_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_asset_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_client_link_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_client_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_client_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_client_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_client_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_client_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_extension_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_feed_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_label_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_manager_link_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_manager_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_manager_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_negative_criterion_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_negative_criterion_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_user_access_invitation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_user_access_invitation_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/customer_user_access_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/customer_user_access_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import customer_user_access_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/detail_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/detail_placement_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import detail_placement_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/display_keyword_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/display_keyword_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import display_keyword_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/distance_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/distance_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import distance_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/domain_category_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/domain_category_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import domain_category_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/dynamic_search_ads_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/dynamic_search_ads_search_term_view_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/expanded_landing_page_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/expanded_landing_page_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/extension_feed_item_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/extension_feed_item_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import extension_feed_item_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_item_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_item_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_item_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_item_set_link_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_item_set_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_item_set_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_item_set_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_item_set_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_item_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_item_target_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_item_target_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_item_target_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_mapping_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_mapping_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_mapping_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_placeholder_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_placeholder_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_placeholder_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/feed_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/gender_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/gender_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import gender_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/geo_target_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/geo_target_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import geo_target_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/geographic_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/geographic_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import geographic_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/google_ads_field_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/google_ads_field_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import google_ads_field_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/google_ads_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/google_ads_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import google_ads_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/group_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/group_placement_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import group_placement_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/hotel_group_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/hotel_group_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import hotel_group_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/hotel_performance_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/hotel_performance_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/income_range_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/income_range_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import income_range_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/invoice_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/invoice_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import invoice_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_plan_ad_group_keyword_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_plan_ad_group_keyword_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_plan_ad_group_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_plan_ad_group_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import keyword_plan_ad_group_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_plan_campaign_keyword_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_plan_campaign_keyword_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_plan_campaign_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_plan_campaign_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import keyword_plan_campaign_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_plan_idea_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_plan_idea_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import keyword_plan_idea_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_plan_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_plan_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import keyword_plan_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/keyword_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/keyword_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import keyword_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/label_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/landing_page_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/landing_page_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import landing_page_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/language_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/language_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import language_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/life_event_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/life_event_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import life_event_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/location_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/location_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import location_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/managed_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/managed_placement_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/media_file_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/media_file_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import media_file_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/merchant_center_link_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/merchant_center_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import merchant_center_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/mobile_app_category_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/mobile_app_category_constant_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/mobile_device_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/mobile_device_constant_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/offline_user_data_job_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/offline_user_data_job_service/transports/base.py
@@ -29,9 +29,7 @@ from google.longrunning import operations_pb2 as operations  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/operating_system_version_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/operating_system_version_constant_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/paid_organic_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/paid_organic_search_term_view_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/parental_status_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/parental_status_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import parental_status_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/payments_account_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/payments_account_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import payments_account_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/product_bidding_category_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/product_bidding_category_constant_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/product_group_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/product_group_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import product_group_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/reach_plan_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/reach_plan_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import reach_plan_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/recommendation_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/recommendation_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import recommendation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/remarketing_action_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/remarketing_action_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import remarketing_action_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/search_term_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import search_term_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/shared_criterion_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/shared_criterion_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import shared_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/shared_set_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/shared_set_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import shared_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/shopping_performance_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/shopping_performance_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/third_party_app_analytics_link_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/third_party_app_analytics_link_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v7.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/topic_constant_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/topic_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import topic_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/topic_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/topic_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import topic_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/user_data_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/user_data_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v7.services.types import user_data_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/user_interest_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/user_interest_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import user_interest_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/user_list_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/user_list_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import user_list_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/user_location_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/user_location_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import user_location_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/video_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/video_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import video_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v7/services/services/webpage_view_service/transports/base.py
+++ b/google/ads/googleads/v7/services/services/webpage_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v7.services.types import webpage_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/accessible_bidding_strategy_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/accessible_bidding_strategy_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/account_budget_proposal_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/account_budget_proposal_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/account_budget_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/account_budget_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import account_budget_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/account_link_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/account_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import account_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_ad_asset_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_ad_asset_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_ad_label_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_ad_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_ad_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_ad_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_ad_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_ad_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_asset_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_audience_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_audience_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_bid_modifier_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_bid_modifier_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_bid_modifier_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_criterion_label_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_criterion_label_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_criterion_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_criterion_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_criterion_simulation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_criterion_simulation_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_extension_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_feed_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_label_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_group_simulation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_group_simulation_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_group_simulation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_parameter_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_parameter_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_parameter_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_schedule_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_schedule_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_schedule_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/ad_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/ad_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import ad_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/age_range_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/age_range_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import age_range_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/asset_field_type_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/asset_field_type_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import asset_field_type_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/asset_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/batch_job_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/batch_job_service/transports/base.py
@@ -29,9 +29,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/bidding_strategy_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/bidding_strategy_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import bidding_strategy_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/bidding_strategy_simulation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/bidding_strategy_simulation_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/billing_setup_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/billing_setup_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import billing_setup_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_asset_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_audience_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_audience_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_bid_modifier_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_bid_modifier_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_bid_modifier_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_budget_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_budget_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_budget_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_criterion_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_criterion_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_criterion_simulation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_criterion_simulation_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_draft_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_draft_service/transports/base.py
@@ -29,9 +29,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_experiment_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_experiment_service/transports/base.py
@@ -30,9 +30,7 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_extension_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_feed_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_label_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_shared_set_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_shared_set_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_shared_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/campaign_simulation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/campaign_simulation_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import campaign_simulation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/carrier_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/carrier_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import carrier_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/change_status_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/change_status_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import change_status_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/click_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/click_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import click_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/combined_audience_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/combined_audience_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import combined_audience_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/conversion_action_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/conversion_action_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import conversion_action_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/conversion_adjustment_upload_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/conversion_adjustment_upload_service/transports/base.py
@@ -28,9 +28,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/conversion_custom_variable_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/conversion_custom_variable_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/conversion_upload_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/conversion_upload_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import conversion_upload_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/currency_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/currency_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import currency_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/custom_audience_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/custom_audience_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import custom_audience_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/custom_interest_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/custom_interest_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import custom_interest_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_asset_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_asset_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_asset_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_client_link_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_client_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_client_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_client_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_client_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_client_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_extension_setting_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_extension_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_feed_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_label_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_manager_link_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_manager_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_manager_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_negative_criterion_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_negative_criterion_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_user_access_invitation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_user_access_invitation_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/customer_user_access_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/customer_user_access_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import customer_user_access_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/detail_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/detail_placement_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import detail_placement_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/detailed_demographic_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/detailed_demographic_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import detailed_demographic_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/display_keyword_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/display_keyword_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import display_keyword_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/distance_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/distance_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import distance_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/domain_category_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/domain_category_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import domain_category_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/dynamic_search_ads_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/dynamic_search_ads_search_term_view_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/expanded_landing_page_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/expanded_landing_page_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/extension_feed_item_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/extension_feed_item_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import extension_feed_item_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_item_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_item_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_item_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_item_set_link_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_item_set_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_item_set_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_item_set_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_item_set_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_item_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_item_target_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_item_target_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_item_target_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_mapping_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_mapping_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_mapping_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_placeholder_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_placeholder_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_placeholder_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/feed_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/feed_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import feed_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/gender_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/gender_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import gender_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/geo_target_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/geo_target_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import geo_target_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/geographic_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/geographic_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import geographic_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/google_ads_field_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/google_ads_field_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import google_ads_field_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/google_ads_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/google_ads_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import google_ads_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/group_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/group_placement_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import group_placement_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/hotel_group_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/hotel_group_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import hotel_group_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/hotel_performance_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/hotel_performance_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/income_range_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/income_range_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import income_range_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/invoice_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/invoice_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import invoice_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_plan_ad_group_keyword_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_plan_ad_group_keyword_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_plan_ad_group_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_plan_ad_group_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import keyword_plan_ad_group_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_plan_campaign_keyword_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_plan_campaign_keyword_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_plan_campaign_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_plan_campaign_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import keyword_plan_campaign_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_plan_idea_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_plan_idea_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import keyword_plan_idea_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_plan_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_plan_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import keyword_plan_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_theme_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_theme_constant_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/keyword_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/keyword_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import keyword_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/label_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/label_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import label_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/landing_page_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/landing_page_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import landing_page_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/language_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/language_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import language_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/life_event_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/life_event_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import life_event_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/location_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/location_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import location_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/managed_placement_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/managed_placement_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/media_file_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/media_file_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import media_file_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/merchant_center_link_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/merchant_center_link_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import merchant_center_link_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/mobile_app_category_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/mobile_app_category_constant_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/mobile_device_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/mobile_device_constant_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/offline_user_data_job_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/offline_user_data_job_service/transports/base.py
@@ -29,9 +29,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/operating_system_version_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/operating_system_version_constant_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/paid_organic_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/paid_organic_search_term_view_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/parental_status_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/parental_status_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import parental_status_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/payments_account_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/payments_account_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import payments_account_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/product_bidding_category_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/product_bidding_category_constant_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/product_group_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/product_group_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import product_group_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/reach_plan_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/reach_plan_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import reach_plan_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/recommendation_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/recommendation_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import recommendation_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/remarketing_action_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/remarketing_action_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import remarketing_action_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/search_term_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import search_term_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/shared_criterion_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/shared_criterion_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import shared_criterion_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/shared_set_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/shared_set_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import shared_set_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/shopping_performance_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/shopping_performance_view_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/smart_campaign_search_term_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/smart_campaign_search_term_view_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/smart_campaign_setting_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/smart_campaign_setting_service/transports/base.py
@@ -29,9 +29,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/smart_campaign_suggest_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/smart_campaign_suggest_service/transports/base.py
@@ -28,9 +28,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/third_party_app_analytics_link_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/third_party_app_analytics_link_service/transports/base.py
@@ -31,9 +31,7 @@ from google.ads.googleads.v8.services.types import (
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/topic_constant_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/topic_constant_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import topic_constant_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/topic_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/topic_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import topic_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/user_data_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/user_data_service/transports/base.py
@@ -26,9 +26,7 @@ from google.ads.googleads.v8.services.types import user_data_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/user_interest_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/user_interest_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import user_interest_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/user_list_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/user_list_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import user_list_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/user_location_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/user_location_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import user_location_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/video_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/video_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import video_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/ads/googleads/v8/services/services/webpage_view_service/transports/base.py
+++ b/google/ads/googleads/v8/services/services/webpage_view_service/transports/base.py
@@ -27,9 +27,7 @@ from google.ads.googleads.v8.services.types import webpage_view_service
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "google-ads-googleads",
-        ).version,
+        gapic_version=pkg_resources.get_distribution("google-ads",).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()


### PR DESCRIPTION
This fixed a bug where `gapic/VERSION` was not being sent in request metadata.

This fix is also incorporated into the generator so it will exist for future releases automatically. 
