### PR TITLE
Retry all search() request pages

### DIFF
--- a/google/ads/googleads/v10/services/services/google_ads_service/client.py
+++ b/google/ads/googleads/v10/services/services/google_ads_service/client.py
@@ -3296,7 +3296,7 @@ class GoogleAdsServiceClient(metaclass=GoogleAdsServiceClientMeta):
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.SearchPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc, request=request, response=response, retry=retry, timeout=timeout, metadata=metadata,
         )
 
         # Done; return the response.

--- a/google/ads/googleads/v10/services/services/google_ads_service/client.py
+++ b/google/ads/googleads/v10/services/services/google_ads_service/client.py
@@ -3288,15 +3288,10 @@ class GoogleAdsServiceClient(metaclass=GoogleAdsServiceClientMeta):
             ),
         )
 
-        # Send the request.
-        response = rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
-        )
-
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.SearchPager(
-            method=rpc, request=request, response=response, retry=retry, timeout=timeout, metadata=metadata,
+            method=rpc, request=request, retry=retry, timeout=timeout, metadata=metadata,
         )
 
         # Done; return the response.

--- a/google/ads/googleads/v10/services/services/google_ads_service/pagers.py
+++ b/google/ads/googleads/v10/services/services/google_ads_service/pagers.py
@@ -42,7 +42,6 @@ class SearchPager:
         self,
         method: Callable[..., google_ads_service.SearchGoogleAdsResponse],
         request: google_ads_service.SearchGoogleAdsRequest,
-        response: google_ads_service.SearchGoogleAdsResponse,
         retry: OptionalRetry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -61,7 +60,7 @@ class SearchPager:
         """
         self._method = method
         self._request = google_ads_service.SearchGoogleAdsRequest(request)
-        self._response = response
+        self._response = None
         self._retry = retry
         self._timeout = timeout
         self._metadata = metadata
@@ -71,13 +70,14 @@ class SearchPager:
 
     @property
     def pages(self) -> Iterable[google_ads_service.SearchGoogleAdsResponse]:
-        yield self._response
-        while self._response.next_page_token:
-            self._request.page_token = self._response.next_page_token
+        while True:
             self._response = self._method(
                 self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata,
             )
             yield self._response
+            if not self._response.next_page_token:
+                break
+            self._request.page_token = self._response.next_page_token
 
     def __iter__(self) -> Iterator[google_ads_service.GoogleAdsRow]:
         for page in self.pages:

--- a/google/ads/googleads/v10/services/services/google_ads_service/pagers.py
+++ b/google/ads/googleads/v10/services/services/google_ads_service/pagers.py
@@ -15,8 +15,10 @@
 #
 from typing import Any, Callable, Iterable, Iterator, Sequence, Tuple
 
+from google.api_core import gapic_v1
 from google.ads.googleads.v10.services.types import google_ads_service
 
+from .client import OptionalRetry
 
 class SearchPager:
     """A pager for iterating through ``search`` requests.
@@ -41,6 +43,8 @@ class SearchPager:
         method: Callable[..., google_ads_service.SearchGoogleAdsResponse],
         request: google_ads_service.SearchGoogleAdsRequest,
         response: google_ads_service.SearchGoogleAdsResponse,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
     ):
         """Instantiate the pager.
@@ -58,6 +62,8 @@ class SearchPager:
         self._method = method
         self._request = google_ads_service.SearchGoogleAdsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -69,7 +75,7 @@ class SearchPager:
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
             self._response = self._method(
-                self._request, metadata=self._metadata
+                self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata,
             )
             yield self._response
 

--- a/google/ads/googleads/v8/services/services/google_ads_service/client.py
+++ b/google/ads/googleads/v8/services/services/google_ads_service/client.py
@@ -2841,7 +2841,7 @@ class GoogleAdsServiceClient(metaclass=GoogleAdsServiceClientMeta):
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.SearchPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc, request=request, response=response, retry=retry, timeout=timeout, metadata=metadata,
         )
 
         # Done; return the response.

--- a/google/ads/googleads/v8/services/services/google_ads_service/client.py
+++ b/google/ads/googleads/v8/services/services/google_ads_service/client.py
@@ -2833,15 +2833,10 @@ class GoogleAdsServiceClient(metaclass=GoogleAdsServiceClientMeta):
             ),
         )
 
-        # Send the request.
-        response = rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
-        )
-
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.SearchPager(
-            method=rpc, request=request, response=response, retry=retry, timeout=timeout, metadata=metadata,
+            method=rpc, request=request, retry=retry, timeout=timeout, metadata=metadata,
         )
 
         # Done; return the response.

--- a/google/ads/googleads/v8/services/services/google_ads_service/pagers.py
+++ b/google/ads/googleads/v8/services/services/google_ads_service/pagers.py
@@ -15,8 +15,9 @@
 #
 from typing import Any, Callable, Iterable, Sequence, Tuple
 
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
 from google.ads.googleads.v8.services.types import google_ads_service
-
 
 class SearchPager:
     """A pager for iterating through ``search`` requests.
@@ -41,6 +42,8 @@ class SearchPager:
         method: Callable[..., google_ads_service.SearchGoogleAdsResponse],
         request: google_ads_service.SearchGoogleAdsRequest,
         response: google_ads_service.SearchGoogleAdsResponse,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
     ):
         """Instantiate the pager.
@@ -58,6 +61,8 @@ class SearchPager:
         self._method = method
         self._request = google_ads_service.SearchGoogleAdsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -69,7 +74,7 @@ class SearchPager:
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
             self._response = self._method(
-                self._request, metadata=self._metadata
+                self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata,
             )
             yield self._response
 

--- a/google/ads/googleads/v8/services/services/google_ads_service/pagers.py
+++ b/google/ads/googleads/v8/services/services/google_ads_service/pagers.py
@@ -41,7 +41,6 @@ class SearchPager:
         self,
         method: Callable[..., google_ads_service.SearchGoogleAdsResponse],
         request: google_ads_service.SearchGoogleAdsRequest,
-        response: google_ads_service.SearchGoogleAdsResponse,
         retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -60,7 +59,7 @@ class SearchPager:
         """
         self._method = method
         self._request = google_ads_service.SearchGoogleAdsRequest(request)
-        self._response = response
+        self._response = None
         self._retry = retry
         self._timeout = timeout
         self._metadata = metadata
@@ -70,13 +69,14 @@ class SearchPager:
 
     @property
     def pages(self) -> Iterable[google_ads_service.SearchGoogleAdsResponse]:
-        yield self._response
-        while self._response.next_page_token:
-            self._request.page_token = self._response.next_page_token
+        while True:
             self._response = self._method(
                 self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata,
             )
             yield self._response
+            if not self._response.next_page_token:
+                break
+            self._request.page_token = self._response.next_page_token
 
     def __iter__(self) -> Iterable[google_ads_service.GoogleAdsRow]:
         for page in self.pages:

--- a/google/ads/googleads/v9/services/services/google_ads_service/client.py
+++ b/google/ads/googleads/v9/services/services/google_ads_service/client.py
@@ -3188,7 +3188,7 @@ class GoogleAdsServiceClient(metaclass=GoogleAdsServiceClientMeta):
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.SearchPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc, request=request, response=response, retry=retry, timeout=timeout, metadata=metadata,
         )
 
         # Done; return the response.

--- a/google/ads/googleads/v9/services/services/google_ads_service/client.py
+++ b/google/ads/googleads/v9/services/services/google_ads_service/client.py
@@ -3180,15 +3180,10 @@ class GoogleAdsServiceClient(metaclass=GoogleAdsServiceClientMeta):
             ),
         )
 
-        # Send the request.
-        response = rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
-        )
-
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.SearchPager(
-            method=rpc, request=request, response=response, retry=retry, timeout=timeout, metadata=metadata,
+            method=rpc, request=request, retry=retry, timeout=timeout, metadata=metadata,
         )
 
         # Done; return the response.

--- a/google/ads/googleads/v9/services/services/google_ads_service/pagers.py
+++ b/google/ads/googleads/v9/services/services/google_ads_service/pagers.py
@@ -42,7 +42,6 @@ class SearchPager:
         self,
         method: Callable[..., google_ads_service.SearchGoogleAdsResponse],
         request: google_ads_service.SearchGoogleAdsRequest,
-        response: google_ads_service.SearchGoogleAdsResponse,
         retry: OptionalRetry = gapic_v1.method.DEFAULT,
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
@@ -61,7 +60,7 @@ class SearchPager:
         """
         self._method = method
         self._request = google_ads_service.SearchGoogleAdsRequest(request)
-        self._response = response
+        self._response = None
         self._retry = retry
         self._timeout = timeout
         self._metadata = metadata
@@ -71,13 +70,14 @@ class SearchPager:
 
     @property
     def pages(self) -> Iterable[google_ads_service.SearchGoogleAdsResponse]:
-        yield self._response
-        while self._response.next_page_token:
-            self._request.page_token = self._response.next_page_token
+        while True:
             self._response = self._method(
                 self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata,
             )
             yield self._response
+            if not self._response.next_page_token:
+                break
+            self._request.page_token = self._response.next_page_token
 
     def __iter__(self) -> Iterable[google_ads_service.GoogleAdsRow]:
         for page in self.pages:

--- a/google/ads/googleads/v9/services/services/google_ads_service/pagers.py
+++ b/google/ads/googleads/v9/services/services/google_ads_service/pagers.py
@@ -15,8 +15,10 @@
 #
 from typing import Any, Callable, Iterable, Sequence, Tuple
 
+from google.api_core import gapic_v1
 from google.ads.googleads.v9.services.types import google_ads_service
 
+from .client import OptionalRetry
 
 class SearchPager:
     """A pager for iterating through ``search`` requests.
@@ -41,6 +43,8 @@ class SearchPager:
         method: Callable[..., google_ads_service.SearchGoogleAdsResponse],
         request: google_ads_service.SearchGoogleAdsRequest,
         response: google_ads_service.SearchGoogleAdsResponse,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
     ):
         """Instantiate the pager.
@@ -58,6 +62,8 @@ class SearchPager:
         self._method = method
         self._request = google_ads_service.SearchGoogleAdsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -69,7 +75,7 @@ class SearchPager:
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
             self._response = self._method(
-                self._request, metadata=self._metadata
+                self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata,
             )
             yield self._response
 


### PR DESCRIPTION
GoogleAdsService provides `search()`, which accepts a `Retry()`. Apply
the `Retry` decorator on all request pages, not just the first.

Resolves: https://github.com/googleads/google-ads-python/issues/597