### PR TITLE
Add url decode for authentication

### DIFF
--- a/examples/authentication/authenticate_in_web_application.py
+++ b/examples/authentication/authenticate_in_web_application.py
@@ -37,6 +37,7 @@ import os
 import re
 import socket
 import sys
+from urllib.parse import unquote
 
 from google_auth_oauthlib.flow import Flow
 
@@ -78,7 +79,7 @@ def main(client_secrets_path, scopes):
 
     # Retrieves an authorization code by opening a socket to receive the
     # redirect request and parsing the query parameters set in the URL.
-    code = _get_authorization_code(passthrough_val)
+    code = unquote(_get_authorization_code(passthrough_val))
 
     # Pass the code back into the OAuth module to get a refresh token.
     flow.fetch_token(code=code)


### PR DESCRIPTION
URL decode enables to parse and generate refresh_token effectively 

Issue solved - when the example is used subsequently, the returning code contains %2F which doesn't get decoded and throws an error