### PR TITLE
Increase upper version boundary of proto-plus to 1.20.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
     # have the same version range.
     "grpcio >= 1.38.1, < 2.0.0",
     "grpcio-status >= 1.38.1, < 2.0.0",
-    "proto-plus == 1.19.6",
+    "proto-plus >= 1.19.6, <= 1.20.6",
     "PyYAML >= 5.1, < 7.0",
     "setuptools >= 40.3.0",
     # Protobuf versions 3.18.* and 3.19.* are incompatible with this


### PR DESCRIPTION
Resolves: https://github.com/googleads/google-ads-python/issues/662

After testing newer versions of proto-plus we discovered that they satisfy our benchmarks, so we're opening up the acceptable versions of proto-plus in our library so we're compatible with other Cloud libraries, and to unlock the Composer team.