### PR TITLE
Corrects typo in generate_user_credentials example

### DIFF
--- a/examples/authentication/generate_user_credentials.py
+++ b/examples/authentication/generate_user_credentials.py
@@ -82,7 +82,7 @@ def main(client_secrets_path, scopes):
 
     # Retrieves an authorization code by opening a socket to receive the
     # redirect request and parsing the query parameters set in the URL.
-    code = unquote(_get_authorization_code(passthrough_val))
+    code = unquote(get_authorization_code(passthrough_val))
 
     # Pass the code back into the OAuth module to get a refresh token.
     flow.fetch_token(code=code)


### PR DESCRIPTION
This PR corrects a typo that was introduced in PR #691. In that PR the definition of this method on line 99 had the underscore removed, but did not change how it was called on line 85. This PR allows the example to run again.