### PR TITLE
loosen protobuf requirements to meet standard packages reqs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "proto-plus == 1.22.0",
     "PyYAML >= 5.1, < 7.0",
     "setuptools >= 40.3.0",
-    "protobuf >= 4.21.5",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5 ",
 ]
 
 with io.open("README.rst", "r", encoding="utf-8") as readme_file:


### PR DESCRIPTION
Check out the issue that was raised about that matter: https://github.com/googleads/google-ads-python/issues/713