### PR TITLE
Fix bug in normalize_and_hash_email_address function

### DIFF
--- a/examples/remarketing/upload_enhanced_conversions_for_leads.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_leads.py
@@ -196,7 +196,7 @@ def normalize_and_hash_email_address(email_address):
     Returns:
         A normalized (lowercase, removed whitespace) and SHA-265 hashed string.
     """
-    normalized_email = email_address.lower()
+    normalized_email = email_address.strip().lower()
     email_parts = normalized_email.split("@")
 
     # Check that there are at least two segments

--- a/examples/remarketing/upload_enhanced_conversions_for_leads.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_leads.py
@@ -198,18 +198,17 @@ def normalize_and_hash_email_address(email_address):
     """
     normalized_email = email_address.lower()
     email_parts = normalized_email.split("@")
-    # Checks whether the domain of the email address is either "gmail.com"
-    # or "googlemail.com". If this regex does not match then this statement
-    # will evaluate to None.
-    is_gmail = re.match(r"^(gmail|googlemail)\.com$", email_parts[1])
 
-    # Check that there are at least two segments and the second segment
-    # matches the above regex expression validating the email domain name.
-    if len(email_parts) > 1 and is_gmail:
-        # Removes any '.' characters from the portion of the email address
-        # before the domain if the domain is gmail.com or googlemail.com.
-        email_parts[0] = email_parts[0].replace(".", "")
-        normalized_email = "@".join(email_parts)
+    # Check that there are at least two segments
+    if len(email_parts) > 1:
+        # Checks whether the domain of the email address is either "gmail.com"
+        # or "googlemail.com". If this regex does not match then this statement
+        # will evaluate to None.
+        if re.match(r"^(gmail|googlemail)\.com$", email_parts[1]):
+            # Removes any '.' characters from the portion of the email address
+            # before the domain if the domain is gmail.com or googlemail.com.
+            email_parts[0] = email_parts[0].replace(".", "")
+            normalized_email = "@".join(email_parts)
 
     return normalize_and_hash(normalized_email)
 

--- a/examples/remarketing/upload_enhanced_conversions_for_web.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_web.py
@@ -230,18 +230,17 @@ def normalize_and_hash_email_address(email_address):
     """
     normalized_email = email_address.lower()
     email_parts = normalized_email.split("@")
-    # Checks whether the domain of the email address is either "gmail.com"
-    # or "googlemail.com". If this regex does not match then this statement
-    # will evaluate to None.
-    is_gmail = re.match(r"^(gmail|googlemail)\.com$", email_parts[1])
 
-    # Check that there are at least two segments and the second segment
-    # matches the above regex expression validating the email domain name.
-    if len(email_parts) > 1 and is_gmail:
-        # Removes any '.' characters from the portion of the email address
-        # before the domain if the domain is gmail.com or googlemail.com.
-        email_parts[0] = email_parts[0].replace(".", "")
-        normalized_email = "@".join(email_parts)
+    # Check that there are at least two segments
+    if len(email_parts) > 1:
+        # Checks whether the domain of the email address is either "gmail.com"
+        # or "googlemail.com". If this regex does not match then this statement
+        # will evaluate to None.
+        if re.match(r"^(gmail|googlemail)\.com$", email_parts[1]):
+            # Removes any '.' characters from the portion of the email address
+            # before the domain if the domain is gmail.com or googlemail.com.
+            email_parts[0] = email_parts[0].replace(".", "")
+            normalized_email = "@".join(email_parts)
 
     return normalize_and_hash(normalized_email)
 

--- a/examples/remarketing/upload_enhanced_conversions_for_web.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_web.py
@@ -228,7 +228,7 @@ def normalize_and_hash_email_address(email_address):
     Returns:
         A normalized (lowercase, removed whitespace) and SHA-265 hashed string.
     """
-    normalized_email = email_address.lower()
+    normalized_email = email_address.strip().lower()
     email_parts = normalized_email.split("@")
 
     # Check that there are at least two segments


### PR DESCRIPTION
### First commit

If `email_address` has no `"@"` in it, the function raises `IndexError list index out of range` in:

```
is_gmail = re.match(r"^(gmail|googlemail)\.com$", email_parts[1])
```
because `email_parts` is a list with only one item.

This PR fix this bug by moving the above line inside the if-block `if len(email_parts) > 1` .


### Second commit

I've added `strip` to `email_address` to honor the [Enhanced Conversions doc](https://developers.google.com/google-ads/api/docs/conversions/enhance-conversions#python) which says:

> [...] In order to standardize the hash results, prior to hashing one of these values you must:
> - Remove leading/trailing whitespaces.
> - [...]