### PR TITLE
update _LOCALE and _COUNTRY_CODE parameters to locale and country_code

### DIFF
--- a/examples/advanced_operations/add_responsive_search_ad_full.py
+++ b/examples/advanced_operations/add_responsive_search_ad_full.py
@@ -380,8 +380,8 @@ def add_geo_targeting(client, customer_id, campaign_resource_name):
     # GeoTargetConstantService.suggest_geo_target_constants() and directly
     # apply GeoTargetConstant.resource_name.
     gtc_request = client.get_type("SuggestGeoTargetConstantsRequest")
-    gtc_request._LOCALE = _LOCALE
-    gtc_request._COUNTRY_CODE = _COUNTRY_CODE
+    gtc_request.locale = _LOCALE
+    gtc_request.country_code = _COUNTRY_CODE
 
     # The location names to get suggested geo target constants.
     gtc_request.location_names.names.extend(
@@ -396,10 +396,10 @@ def add_geo_targeting(client, customer_id, campaign_resource_name):
         print(
             f"{geo_target_constant.resource_name} "
             f"({geo_target_constant.name}, "
-            f"{geo_target_constant._COUNTRY_CODE}, "
+            f"{geo_target_constant.country_code}, "
             f"{geo_target_constant.target_type}, "
             f"{geo_target_constant.status.name}) "
-            f"is found in _LOCALE ({suggestion._LOCALE}) "
+            f"is found in _LOCALE ({suggestion.locale}) "
             f"with reach ({suggestion.reach}) "
             f"from search term ({suggestion.search_term})."
         )


### PR DESCRIPTION
The `_LOCALE` and `_COUNTRY_CODE` parameters on the `gtc_request` object below are not present:

```python
    geo_target_constant_service = client.get_service(
        "GeoTargetConstantService"
    )

    # Search by location names from
    # GeoTargetConstantService.suggest_geo_target_constants() and directly
    # apply GeoTargetConstant.resource_name.
    gtc_request = client.get_type("SuggestGeoTargetConstantsRequest")
```

See https://github.com/googleads/google-ads-python/blob/b6a5dffccc25872fd38925926e59988186e3cc15/examples/targeting/get_geo_target_constants_by_names.py#L34-L60 for the updated usage of this object. 

This PR updates usage in the `add_responsive_search_add_full.py` script example.