### PR TITLE
Move from `mock` to `unittest.mock`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,6 @@ def tests(session):
     session.install(".")
     # modules for testing
     session.install(
-        "mock>=4.0.3",
         "pyfakefs>=3.5,<3.7",
         "coverage==6.5.0",
     )
@@ -48,7 +47,6 @@ def tests_minimum_dependency_versions(session):
     session.install(".")
     # modules for testing
     session.install(
-        "mock>=4.0.3",
         "pyfakefs>=3.5,<3.7",
         "coverage==6.5.0",
         # Google-published dependencies pinned to the

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -15,7 +15,7 @@
 
 from importlib import import_module
 from inspect import getmembers
-import mock
+from unittest import mock
 import os
 import pickle
 from pyfakefs.fake_filesystem_unittest import TestCase as FileTestCase

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests the configuration helper module."""
 
-import mock
+from unittest import mock
 import os
 import yaml
 from pyfakefs.fake_filesystem_unittest import TestCase as FileTestCase

--- a/tests/interceptors/exception_interceptor_test.py
+++ b/tests/interceptors/exception_interceptor_test.py
@@ -14,7 +14,7 @@
 """Tests for the Exception gRPC Interceptor."""
 
 import grpc
-import mock
+from unittest import mock
 from unittest import TestCase
 
 from google.protobuf.message import Message as ProtobufMessageType

--- a/tests/interceptors/interceptor_test.py
+++ b/tests/interceptors/interceptor_test.py
@@ -15,7 +15,7 @@
 
 
 from importlib import import_module
-import mock
+from unittest import mock
 from unittest import TestCase
 
 import grpc

--- a/tests/interceptors/logging_interceptor_test.py
+++ b/tests/interceptors/logging_interceptor_test.py
@@ -17,10 +17,9 @@
 from importlib import import_module
 import json
 import logging
+from unittest import mock
 from unittest import TestCase
 from types import SimpleNamespace
-
-import mock
 
 from google.ads.googleads import client as Client
 from google.ads.googleads.interceptors import LoggingInterceptor

--- a/tests/interceptors/metadata_interceptor_test.py
+++ b/tests/interceptors/metadata_interceptor_test.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 """Tests for the Metadata gRPC Interceptor."""
 
+from unittest import mock
 from unittest import TestCase
 import sys
-
-import mock
 
 from google.ads.googleads.interceptors import MetadataInterceptor
 

--- a/tests/oauth2_test.py
+++ b/tests/oauth2_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for the OAuth2 helper module."""
 
-import mock
+from unittest import mock
 from unittest import TestCase
 
 from google.ads.googleads import oauth2


### PR DESCRIPTION
`mock` was merged into Python 3.3 as `unittest.mock`: https://docs.python.org/dev/whatsnew/3.3.html

This PR updates the tests to use it rather than the backport packgae.