### PR TITLE
Use unittest's `--buffer` option

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,22 @@ import nox
 
 PYTHON_VERSIONS = ["3.7"]
 
+TEST_COMMAND = [
+    "coverage",
+    "run",
+    "--append",
+    "-m",
+    "unittest",
+    "discover",
+    "--buffer",
+    "-s=tests",
+    "-p",
+    "*_test.py",
+]
+COVERAGE_COMMAND = [
+    "coverage", "report", "-m", "--omit=.nox/*,examples/*,*/__init__.py",
+]
+
 
 @nox.session(python=PYTHON_VERSIONS)
 def tests(session):
@@ -26,20 +42,9 @@ def tests(session):
         "pyfakefs>=3.5,<3.7",
         "coverage==6.5.0",
     )
-    session.run(
-        "coverage",
-        "run",
-        "--append",
-        "-m",
-        "unittest",
-        "discover",
-        "-s=tests",
-        "-p",
-        "*_test.py",
-    )
-    session.run(
-        "coverage", "report", "-m", "--omit=.nox/*,examples/*,*/__init__.py"
-    )
+    session.run(*TEST_COMMAND)
+    session.run(*COVERAGE_COMMAND)
+
 
 # This session runs all the unit tests but with the lowest-possible versions
 # of supported dependencies that are published by Google.
@@ -61,17 +66,5 @@ def tests_minimum_dependency_versions(session):
         "grpcio==1.38.1",
         "grpcio-status==1.38.1",
     )
-    session.run(
-        "coverage",
-        "run",
-        "--append",
-        "-m",
-        "unittest",
-        "discover",
-        "-s=tests",
-        "-p",
-        "*_test.py",
-    )
-    session.run(
-        "coverage", "report", "-m", "--omit=.nox/*,examples/*,*/__init__.py"
-    )
+    session.run(*TEST_COMMAND)
+    session.run(*COVERAGE_COMMAND)


### PR DESCRIPTION
[`--buffer`](https://docs.python.org/3.11/library/unittest.html#cmdoption-unittest-b) captures stdout and stderr, stopping it from polluting the test run output. This is the default behaviour in pytest.

Before:

```
..............................................................The 'path_to_private_key_file' configuration key and 'GOOGLE_ADS_PATH_TO_PRIVATE_KEY_FILE' environment variable are deprecated and support will be removed at some point in the future. Please use 'json_key_file_path' configuration key or 'GOOGLE_ADS_JSON_KEY_FILE_PATH' environment variable instead.
The 'delegated_account' configuration key and 'GOOGLE_ADS_DELEGATED_PATH' environment variable are deprecated and support will be removed at some point in the future. Please use 'impersonated_email' configuration key or 'GOOGLE_ADS_IMPERSONATED_EMAIL' environment variable instead.
...................The 'path_to_private_key_file' configuration key and 'GOOGLE_ADS_PATH_TO_PRIVATE_KEY_FILE' environment variable are deprecated and support will be removed at some point in the future. Please use 'json_key_file_path' configuration key or 'GOOGLE_ADS_JSON_KEY_FILE_PATH' environment variable instead.
The 'delegated_account' configuration key and 'GOOGLE_ADS_DELEGATED_PATH' environment variable are deprecated and support will be removed at some point in the future. Please use 'impersonated_email' configuration key or 'GOOGLE_ADS_IMPERSONATED_EMAIL' environment variable instead.
........................................................................................................................
----------------------------------------------------------------------
Ran 201 tests in 16.344s
```

After:

```
.........................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 201 tests in 16.243s
```