### PR TITLE
Remove normalization and hashing of postal code and country code

### DIFF
--- a/examples/remarketing/upload_enhanced_conversions_for_web.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_web.py
@@ -144,12 +144,8 @@ def main(
             address_info.hashed_last_name = normalize_and_hash(
                 raw_record["last_name"]
             )
-            address_info.hashed_street_address = normalize_and_hash(
-                raw_record["country_code"]
-            )
-            address_info.hashed_street_address = normalize_and_hash(
-                raw_record["postal_code"]
-            )
+            address_info.hashed_street_address = raw_record["country_code"]
+            address_info.hashed_street_address = raw_record["postal_code"]
             # Adds the address identifier to the conversion adjustment.
             conversion_adjustment.user_identifiers.append(address_identifier)
             # [END add_user_identifiers]


### PR DESCRIPTION
Only first and last name in the physical address need to be normalized and hashed. See also [this Help Center article](https://support.google.com/google-ads/answer/13258081).