### PR TITLE
Bringing in service account string capability

### DIFF
--- a/google/ads/googleads/config.py
+++ b/google/ads/googleads/config.py
@@ -36,7 +36,8 @@ _OPTIONAL_KEYS = (
 )
 _CONFIG_FILE_PATH_KEY = ("configuration_file_path",)
 _OAUTH2_INSTALLED_APP_KEYS = ("client_id", "client_secret", "refresh_token")
-_OAUTH2_REQUIRED_SERVICE_ACCOUNT_KEYS = ("json_key_file_path",)
+_OAUTH2_REQUIRED_SERVICE_ACCOUNT_PATH_KEYS = ("json_key_file_path",)
+_OAUTH2_REQUIRED_SERVICE_ACCOUNT_STRING_KEYS = ("json_key_string",)
 _OAUTH2_OPTIONAL_SERVICE_ACCOUNT_KEYS = ("impersonated_email",)
 # These keys are deprecated environment variables that can be used in place of
 # the primary OAuth2 service account keys for backwards compatibility. They will
@@ -51,7 +52,8 @@ _KEYS_ENV_VARIABLES_MAP = {
     + _OPTIONAL_KEYS
     + _OAUTH2_INSTALLED_APP_KEYS
     + _CONFIG_FILE_PATH_KEY
-    + _OAUTH2_REQUIRED_SERVICE_ACCOUNT_KEYS
+    + _OAUTH2_REQUIRED_SERVICE_ACCOUNT_PATH_KEYS
+    + _OAUTH2_REQUIRED_SERVICE_ACCOUNT_STRING_KEYS
     + _OAUTH2_OPTIONAL_SERVICE_ACCOUNT_KEYS
     + _SECONDARY_OAUTH2_SERVICE_ACCOUNT_KEYS
 }
@@ -352,13 +354,21 @@ def get_oauth2_installed_app_keys():
     return _OAUTH2_INSTALLED_APP_KEYS
 
 
-def get_oauth2_required_service_account_keys():
-    """A getter that returns the required OAuth2 service account keys.
+def get_oauth2_required_service_account_path_keys():
+    """A getter that returns the required OAuth2 service account keys relying on path.
 
     Returns:
         A tuple containing the required keys as strs.
     """
-    return _OAUTH2_REQUIRED_SERVICE_ACCOUNT_KEYS
+    return _OAUTH2_REQUIRED_SERVICE_ACCOUNT_PATH_KEYS
+
+def get_oauth2_required_service_account_string_keys():
+    """A getter that returns the required OAuth2 service account keys relying on string.
+
+    Returns:
+        A tuple containing the required keys as strs.
+    """
+    return _OAUTH2_REQUIRED_SERVICE_ACCOUNT_STRING_KEYS
 
 
 def convert_login_customer_id_to_str(config_data):

--- a/google/ads/googleads/oauth2.py
+++ b/google/ads/googleads/oauth2.py
@@ -132,6 +132,10 @@ def get_credentials(config_data):
             config_data.get("refresh_token"),
             http_proxy=config_data.get("http_proxy"),
         )
+    elif "GOOGLE_ADS_SERVICE_ACCOUNT_INFO_STRING" in os.environ:
+        return get_service_account_credentials(
+            None,
+            config_data.get("impersonated_email"),)
     elif all(key in config_data for key in required_service_account_keys):
         # Using the Service Account Flow
         return get_service_account_credentials(
@@ -139,11 +143,6 @@ def get_credentials(config_data):
             config_data.get("impersonated_email"),
             http_proxy=config_data.get("http_proxy"),
         )
-    elif "GOOGLE_ADS_SERVICE_ACCOUNT_INFO_STRING" in os.environ:
-        return get_service_account_credentials(
-            None,
-            config_data.get("impersonated_email"),
-            http_proxy=config_data.get("http_proxy"),)
     else:
         raise ValueError(
             "Your YAML file is incorrectly configured for OAuth2. "

--- a/google/ads/googleads/oauth2.py
+++ b/google/ads/googleads/oauth2.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A set of functions to help initialize OAuth2 credentials."""
-
-import os
 import json
 import functools
 from requests import Session
@@ -81,34 +79,33 @@ def get_installed_app_credentials(
 
 # In environments where it is preferable to supply secrets or other configuration via
 # environment variables or where it is not feasible to make a .json key file available,
-# file available, you may instead provide credential as a JSON string in the
-# `GOOGLE_ADS_SERVICE_ACCOUNT_INFO_STRING` environment variable. This JSON string
+# file available, you may instead provide credential as a JSON string. This JSON string
 # should contain the same contents and be formatted the same way as the contents
 # of a .json key file.
 
 @_initialize_credentials_decorator
 def get_service_account_credentials(
-    json_key_file_path, subject, http_proxy=None, scopes=_SERVICE_ACCOUNT_SCOPES
+    json_key, subject, http_proxy=None, scopes=_SERVICE_ACCOUNT_SCOPES, is_path=True
 ):
     """Creates and returns an instance of oauth2.service_account.Credentials.
 
     Args:
-        json_key_file_path: A str of the path to the private key file location.
+        json_key: A str of the path to the private key file location or str of the JSON key file contents (when is_path=False)
         subject: A str of the email address of the delegated account.
         scopes: A list of additional scopes.
+        is_path: A boolean indicating whether the json_key is a path or a string.
 
     Returns:
         An instance of oauth2.credentials.Credentials
     """
-    service_account_info = os.getenv("GOOGLE_ADS_SERVICE_ACCOUNT_INFO_STRING")
-    if service_account_info:
+    if not is_path:
         return ServiceAccountCreds.from_service_account_info(
-            json.loads(service_account_info), subject=subject, scopes=scopes
+            json.loads(json_key), subject=subject, scopes=scopes
         )
-    return ServiceAccountCreds.from_service_account_file(
-        json_key_file_path, subject=subject, scopes=scopes
-    )
-
+    else:
+        return ServiceAccountCreds.from_service_account_file(
+            json_key, subject=subject, scopes=scopes
+        )
 
 def get_credentials(config_data):
     """Decides which type of credentials to return based on the given config.
@@ -120,8 +117,11 @@ def get_credentials(config_data):
         An initialized credentials instance.
     """
     required_installed_app_keys = config.get_oauth2_installed_app_keys()
-    required_service_account_keys = (
-        config.get_oauth2_required_service_account_keys()
+    required_service_account_path_keys = (
+        config.get_oauth2_required_service_account_path_keys()
+    )
+    required_service_account_string_keys = (
+        config.get_oauth2_required_service_account_string_keys()
     )
 
     if all(key in config_data for key in required_installed_app_keys):
@@ -132,23 +132,28 @@ def get_credentials(config_data):
             config_data.get("refresh_token"),
             http_proxy=config_data.get("http_proxy"),
         )
-    elif "GOOGLE_ADS_SERVICE_ACCOUNT_INFO_STRING" in os.environ:
-        return get_service_account_credentials(
-            None,
-            config_data.get("impersonated_email"),)
-    elif all(key in config_data for key in required_service_account_keys):
-        # Using the Service Account Flow
+    elif all(key in config_data for key in required_service_account_path_keys):
+        # Using the Service Account Path Flow
         return get_service_account_credentials(
             config_data.get("json_key_file_path"),
             config_data.get("impersonated_email"),
             http_proxy=config_data.get("http_proxy"),
         )
+    elif all(key in config_data for key in required_service_account_string_keys):
+        # Using the Service Account String Flow
+        return get_service_account_credentials(
+            config_data.get("json_key_string"),
+            config_data.get("impersonated_email"),
+            http_proxy=config_data.get("http_proxy"),
+            is_path=False,
+        )
     else:
         raise ValueError(
             "Your YAML file is incorrectly configured for OAuth2. "
             "You need to define credentials for either the OAuth2 "
-            "installed application flow ({}) or service account "
-            "flow ({}).".format(
-                required_installed_app_keys, required_service_account_keys
+            "installed application flow ({}) or service account using path"
+            "flow ({}). or service account using string"
+            "flow ({})".format(
+                required_installed_app_keys, required_service_account_path_keys, required_service_account_string_keys
             )
         )


### PR DESCRIPTION
# Description:

This PR adds the ability to provide credentials via an environment variable for use cases where adding a .json to the filesystem in the runtime environment is not feasible for security reasons.

# Testing:

Called get_credentials in oauth2.py by declaring a ` "json_key_string"` (item) with personal credentials in `config_data` (dictionary)

The result was that we received as a valid credentials object.

# References:

Would highly recommend seeing this as similar approach has been executed in big query api library!

BQ: https://github.com/anelendata/tap-bigquery/blob/master/tap_bigquery/sync_bigquery.py
Implementation: https://gitlab.1password.io/data/data-issues/-/issues/3347#note_3160542