### PR TITLE
Add support for python 3.13 (#896)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update -qy && \
         python3.9 \
         python3.10 \
         python3.11 \
-        python3.12 && \
+        python3.12 \
+        python3.13 && \
     curl -fsSo /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
     python3.8 /tmp/get-pip.py && \
     python3.8 -m pip install --no-cache-dir --upgrade pip && \
@@ -33,6 +34,8 @@ RUN apt-get update -qy && \
     python3.11 -m pip install --no-cache-dir --upgrade pip && \
     python3.12 /tmp/get-pip.py && \
     python3.12 -m pip install --no-cache-dir --upgrade pip && \
+    python3.13 /tmp/get-pip.py && \
+    python3.13 -m pip install --no-cache-dir --upgrade pip && \
     rm /tmp/get-pip.py && \
     python3 -m pip install --no-cache-dir "nox>=2020.12.31,<2022.6" && \
     rm -rf /var/cache/apt/lists

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@
 
 import nox
 
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 PROTOBUF_IMPLEMENTATIONS = ["python", "upb"]
 
 TEST_COMMAND = [
@@ -74,8 +74,8 @@ def tests_minimum_dependency_versions(session, protobuf_implementation):
         "protobuf==4.25.0",
         "google-auth-oauthlib==0.3.0",
         "googleapis-common-protos==1.56.3",
-        "grpcio==1.59.0",
-        "grpcio-status==1.59.0",
+        "grpcio==1.70.0",
+        "grpcio-status==1.62.3",
     )
     session.run(*FREEZE_COMMAND)
     session.run(

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ install_requires = [
     # NOTE: Source code for grpcio and grpcio-status exist in the same
     # grpc/grpc monorepo and thus these two dependencies should always
     # have the same version range.
-    "grpcio >= 1.59.0, < 2.0.0",
-    "grpcio-status >= 1.59.0, < 2.0.0",
+    "grpcio >= 1.70.0, < 2.0.0",
+    "grpcio-status >= 1.63.2, < 2.0.0",
     "proto-plus >= 1.22.3, < 2.0.0",
     "PyYAML >= 5.1, < 7.0",
     "protobuf >= 4.25.0, < 6.0.0",
@@ -49,10 +49,11 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     description="Client library for the Google Ads API",
     include_package_data=True,
-    python_requires=">=3.8, <3.13",
+    python_requires=">=3.8",
     long_description=long_description,
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
Remove python 3.13 upper bound, and adjust version requirements for `grpcio` and `grpcio-status` to support this change.

Technically they don't need to be bumped, but are not available as cheese wheels for Python 3.13, so require build dependencies in the test environment or a cached wheel built manually.

Tested in the Docker image with the `nox` command.