### PR TITLE
Add type hints to examples/assets files

### DIFF
--- a/examples/assets/add_call.py
+++ b/examples/assets/add_call.py
@@ -16,19 +16,33 @@
 
 
 import argparse
+from typing import Optional, Sequence
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.common.types.criteria import AdScheduleInfo
+from google.ads.googleads.v19.enums.types.day_of_week import DayOfWeekEnum
+from google.ads.googleads.v19.enums.types.minute_of_hour import MinuteOfHourEnum
+from google.ads.googleads.v19.enums.types.call_conversion_reporting_state import CallConversionReportingStateEnum
+from google.ads.googleads.v19.services.types.customer_asset_service import CustomerAssetOperation
+from google.ads.googleads.v19.resources.types.customer_asset import CustomerAsset
+from google.ads.googleads.v19.enums.types.asset_field_type import AssetFieldTypeEnum
 
 # Country code is a two-letter ISO-3166 code, for a list of all codes see:
 # https://developers.google.com/google-ads/api/reference/data/codes-formats#expandable-17
-_DEFAULT_PHONE_COUNTRY = "US"
+_DEFAULT_PHONE_COUNTRY: str = "US"
 
 
 def main(
-    client, customer_id, phone_number, phone_country, conversion_action_id
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    phone_number: str,
+    phone_country: str,
+    conversion_action_id: Optional[str],
+) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -38,15 +52,19 @@ def main(
         phone_country: a two-letter ISO-3166 code.
         conversion_action_id: an ID for a conversion action.
     """
-    asset_resource_name = add_call_asset(
+    asset_resource_name: str = add_call_asset(
         client, customer_id, phone_number, phone_country, conversion_action_id
     )
     link_asset_to_account(client, customer_id, asset_resource_name)
 
 
 def add_call_asset(
-    client, customer_id, phone_number, phone_country, conversion_action_id
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    phone_number: str,
+    phone_country: str,
+    conversion_action_id: Optional[str],
+) -> str:
     """Creates a new asset for the call.
 
     Args:
@@ -59,13 +77,13 @@ def add_call_asset(
     Returns:
         a resource name for a new call asset.
     """
-    operation = client.get_type("AssetOperation")
+    operation: AssetOperation = client.get_type("AssetOperation")
     # Creates the call asset.
-    asset = operation.create.call_asset
+    asset: Asset = operation.create.call_asset
     asset.country_code = phone_country
     asset.phone_number = phone_number
     # Optional: Specifies day and time intervals for which the asset may serve.
-    ad_schedule = client.get_type("AdScheduleInfo")
+    ad_schedule: AdScheduleInfo = client.get_type("AdScheduleInfo")
     # Sets the day of this schedule as Monday.
     ad_schedule.day_of_week = client.enums.DayOfWeekEnum.MONDAY
     # Sets the start hour to 9am.
@@ -93,13 +111,15 @@ def add_call_asset(
     response = asset_service.mutate_assets(
         customer_id=customer_id, operations=[operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(f"Created a call asset with resource name: '{resource_name}'")
 
     return resource_name
 
 
-def link_asset_to_account(client, customer_id, asset_resource_name):
+def link_asset_to_account(
+    client: GoogleAdsClient, customer_id: str, asset_resource_name: str
+) -> None:
     """Links the call asset at the account level to serve in eligible campaigns.
 
     Args:
@@ -107,8 +127,10 @@ def link_asset_to_account(client, customer_id, asset_resource_name):
         customer_id: a client customer ID.
         asset_resource_name: a resource name for the call asset.
     """
-    operation = client.get_type("CustomerAssetOperation")
-    customer_asset = operation.create
+    operation: CustomerAssetOperation = client.get_type(
+        "CustomerAssetOperation"
+    )
+    customer_asset: CustomerAsset = operation.create
     customer_asset.asset = asset_resource_name
     customer_asset.field_type = client.enums.AssetFieldTypeEnum.CALL
 
@@ -116,12 +138,12 @@ def link_asset_to_account(client, customer_id, asset_resource_name):
     response = customer_asset_service.mutate_customer_assets(
         customer_id=customer_id, operations=[operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(f"Created a customer asset with resource name: '{resource_name}'")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description=("Adds a call asset to a specific account.")
     )
     # The following argument(s) should be provided to run the example.
@@ -157,11 +179,13 @@ if __name__ == "__main__":
         help=("An optional conversion action ID to attribute conversions to."),
     )
 
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(

--- a/examples/assets/add_hotel_callout.py
+++ b/examples/assets/add_hotel_callout.py
@@ -16,14 +16,22 @@
 
 
 import argparse
+from typing import List, Sequence
 import sys
 
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.services.types.customer_asset_service import CustomerAssetOperation
+from google.ads.googleads.v19.resources.types.customer_asset import CustomerAsset
+from google.ads.googleads.v19.enums.types.asset_field_type import AssetFieldTypeEnum
 
 
-def main(client, customer_id, language_code):
+def main(
+    client: GoogleAdsClient, customer_id: str, language_code: str
+) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -32,7 +40,7 @@ def main(client, customer_id, language_code):
         language_code: the language of the hotel callout feed item text.
     """
     # Creates assets for the hotel callout assets.
-    asset_resource_names = add_hotel_callout_assets(
+    asset_resource_names: List[str] = add_hotel_callout_assets(
         client, customer_id, language_code
     )
 
@@ -41,7 +49,9 @@ def main(client, customer_id, language_code):
     link_asset_to_account(client, customer_id, asset_resource_names)
 
 
-def add_hotel_callout_assets(client, customer_id, language_code):
+def add_hotel_callout_assets(
+    client: GoogleAdsClient, customer_id: str, language_code: str
+) -> List[str]:
     """Creates new assets for the hotel callout.
 
     Args:
@@ -52,11 +62,11 @@ def add_hotel_callout_assets(client, customer_id, language_code):
     Returns:
         a list of asset resource names.
     """
-    operations = []
+    operations: List[AssetOperation] = []
     # Create a hotel callout asset operation for each of the below texts.
     for text in ["Activities", "Facilities"]:
-        operation = client.get_type("AssetOperation")
-        asset = operation.create
+        operation: AssetOperation = client.get_type("AssetOperation")
+        asset: Asset = operation.create
         asset.hotel_callout_asset.text = text
         asset.hotel_callout_asset.language_code = language_code
         operations.append(operation)
@@ -66,7 +76,9 @@ def add_hotel_callout_assets(client, customer_id, language_code):
     response = asset_service.mutate_assets(
         customer_id=customer_id, operations=operations
     )
-    resource_names = [result.resource_name for result in response.results]
+    resource_names: List[str] = [
+        result.resource_name for result in response.results
+    ]
 
     # Prints information about the result.
     for resource_name in resource_names:
@@ -78,7 +90,9 @@ def add_hotel_callout_assets(client, customer_id, language_code):
     return resource_names
 
 
-def link_asset_to_account(client, customer_id, resource_names):
+def link_asset_to_account(
+    client: GoogleAdsClient, customer_id: str, resource_names: List[str]
+) -> None:
     """Links Asset at the Customer level to serve in all eligible campaigns.
 
     Args:
@@ -87,10 +101,12 @@ def link_asset_to_account(client, customer_id, resource_names):
         resource_names: a list of asset resource names.
     """
     # Creates a CustomerAsset link for each Asset resource name provided.
-    operations = []
+    operations: List[CustomerAssetOperation] = []
     for resource_name in resource_names:
-        operation = client.get_type("CustomerAssetOperation")
-        asset = operation.create
+        operation: CustomerAssetOperation = client.get_type(
+            "CustomerAssetOperation"
+        )
+        asset: CustomerAsset = operation.create
         asset.asset = resource_name
         asset.field_type = client.enums.AssetFieldTypeEnum.HOTEL_CALLOUT
         operations.append(operation)
@@ -108,7 +124,7 @@ def link_asset_to_account(client, customer_id, resource_names):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description=(
             "Adds a hotel callout asset and adds the asset to the given "
             "account."
@@ -133,11 +149,13 @@ if __name__ == "__main__":
             "https://developers.google.com/hotels/hotel-ads/api-reference/language-codes."
         ),
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id, args.language_code)

--- a/examples/assets/add_lead_form_asset.py
+++ b/examples/assets/add_lead_form_asset.py
@@ -19,14 +19,28 @@ Run add_campaigns.py to create a campaign.
 
 
 import argparse
+from typing import List, Sequence
 import sys
 from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.common.types.asset_types import LeadFormAsset
+from google.ads.googleads.v19.enums.types.lead_form_call_to_action_type import LeadFormCallToActionTypeEnum
+from google.ads.googleads.v19.enums.types.lead_form_field_user_input_type import LeadFormFieldUserInputTypeEnum
+from google.ads.googleads.v19.common.types.asset_types import LeadFormField
+from google.ads.googleads.v19.enums.types.lead_form_post_submit_call_to_action_type import LeadFormPostSubmitCallToActionTypeEnum
+from google.ads.googleads.v19.common.types.asset_types import LeadFormDeliveryMethod
+from google.ads.googleads.v19.services.types.campaign_asset_service import CampaignAssetOperation
+from google.ads.googleads.v19.resources.types.campaign_asset import CampaignAsset
+from google.ads.googleads.v19.enums.types.asset_field_type import AssetFieldTypeEnum
 
 
-def main(client, customer_id, campaign_id):
+def main(
+    client: GoogleAdsClient, customer_id: str, campaign_id: str
+) -> None:
     """Creates a lead form and lead form extension for the given campaign.
 
     Args:
@@ -34,14 +48,16 @@ def main(client, customer_id, campaign_id):
         customer_id: The Google Ads customer ID.
         campaign_id: The ID for a Campaign belonging to the given customer.
     """
-    lead_form_asset_resource_name = create_lead_form_asset(client, customer_id)
+    lead_form_asset_resource_name: str = create_lead_form_asset(
+        client, customer_id
+    )
     create_lead_form_campaign_asset(
         client, customer_id, campaign_id, lead_form_asset_resource_name
     )
 
 
 # [START add_lead_form_asset]
-def create_lead_form_asset(client, customer_id):
+def create_lead_form_asset(client: GoogleAdsClient, customer_id: str) -> str:
     """Creates a lead form asset using the given customer ID.
 
     Args:
@@ -52,13 +68,13 @@ def create_lead_form_asset(client, customer_id):
         A str of the resource name for the newly created lead form asset.
     """
     asset_service = client.get_service("AssetService")
-    asset_operation = client.get_type("AssetOperation")
-    asset = asset_operation.create
+    asset_operation: AssetOperation = client.get_type("AssetOperation")
+    asset: Asset = asset_operation.create
     asset.name = f"Interplanetary Cruise #{uuid4()} Lead Form"
     asset.final_urls.append("http://example.com/jupiter")
 
     # Creates a new LeadFormAsset instance.
-    lead_form_asset = asset.lead_form_asset
+    lead_form_asset: LeadFormAsset = asset.lead_form_asset
 
     # Specify the details of the extension that the users will see.
     lead_form_asset.call_to_action_type = (
@@ -76,19 +92,19 @@ def create_lead_form_asset(client, customer_id):
 
     # Define the fields to be displayed to the user.
     input_type_enum = client.enums.LeadFormFieldUserInputTypeEnum
-    lead_form_field_1 = client.get_type("LeadFormField")
+    lead_form_field_1: LeadFormField = client.get_type("LeadFormField")
     lead_form_field_1.input_type = input_type_enum.FULL_NAME
     lead_form_asset.fields.append(lead_form_field_1)
 
-    lead_form_field_2 = client.get_type("LeadFormField")
+    lead_form_field_2: LeadFormField = client.get_type("LeadFormField")
     lead_form_field_2.input_type = input_type_enum.EMAIL
     lead_form_asset.fields.append(lead_form_field_2)
 
-    lead_form_field_3 = client.get_type("LeadFormField")
+    lead_form_field_3: LeadFormField = client.get_type("LeadFormField")
     lead_form_field_3.input_type = input_type_enum.PHONE_NUMBER
     lead_form_asset.fields.append(lead_form_field_3)
 
-    lead_form_field_4 = client.get_type("LeadFormField")
+    lead_form_field_4: LeadFormField = client.get_type("LeadFormField")
     lead_form_field_4.input_type = input_type_enum.PREFERRED_CONTACT_TIME
     lead_form_field_4.single_choice_answers.answers.extend(
         ["Before 9 AM", "Anytime", "After 5 PM"]
@@ -118,7 +134,9 @@ def create_lead_form_asset(client, customer_id):
     # Optional: Define a delivery method for the form response. See
     # https://developers.google.com/google-ads/webhook/docs/overview for more
     # details on how to define a webhook.
-    delivery_method = client.get_type("LeadFormDeliveryMethod")
+    delivery_method: LeadFormDeliveryMethod = client.get_type(
+        "LeadFormDeliveryMethod"
+    )
     delivery_method.webhook.advertiser_webhook_url = (
         "http://example.com/webhook"
     )
@@ -130,7 +148,7 @@ def create_lead_form_asset(client, customer_id):
     response = asset_service.mutate_assets(
         customer_id=customer_id, operations=[asset_operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
 
     print(f"Asset with resource name {resource_name} was created.")
 
@@ -140,19 +158,25 @@ def create_lead_form_asset(client, customer_id):
 
 # [START add_lead_form_asset_1]
 def create_lead_form_campaign_asset(
-    client, customer_id, campaign_id, lead_form_asset_resource_name
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    campaign_id: str,
+    lead_form_asset_resource_name: str,
+) -> None:
     """Creates the lead form campaign asset.
 
     Args:
         client: An initialized GoogleAdsClient instance.
         customer_id: The Google Ads customer ID.
         campaign_id: The ID for a Campaign belonging to the given customer.
+        lead_form_asset_resource_name: The resource name of the lead form asset.
     """
     campaign_service = client.get_service("CampaignService")
     campaign_asset_service = client.get_service("CampaignAssetService")
-    campaign_asset_operation = client.get_type("CampaignAssetOperation")
-    campaign_asset = campaign_asset_operation.create
+    campaign_asset_operation: CampaignAssetOperation = client.get_type(
+        "CampaignAssetOperation"
+    )
+    campaign_asset: CampaignAsset = campaign_asset_operation.create
     campaign_asset.asset = lead_form_asset_resource_name
     campaign_asset.field_type = client.enums.AssetFieldTypeEnum.LEAD_FORM
     campaign_asset.campaign = campaign_service.campaign_path(
@@ -171,7 +195,7 @@ def create_lead_form_campaign_asset(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="This code example creates a lead form and a lead form "
         "asset for a campaign. Run add_campaigns.py to create a "
         "campaign."
@@ -191,11 +215,13 @@ if __name__ == "__main__":
         required=True,
         help="The ID of a Campaign belonging to the given customer.",
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id, args.campaign_id)

--- a/examples/assets/add_prices.py
+++ b/examples/assets/add_prices.py
@@ -16,14 +16,25 @@
 
 
 import argparse
+from typing import List, Optional, Sequence
 import sys
 from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.common.types.asset_types import PriceAsset
+from google.ads.googleads.v19.enums.types.price_extension_type import PriceExtensionTypeEnum
+from google.ads.googleads.v19.enums.types.price_extension_price_qualifier import PriceExtensionPriceQualifierEnum
+from google.ads.googleads.v19.common.types.asset_types import PriceOffering
+from google.ads.googleads.v19.enums.types.price_extension_price_unit import PriceExtensionPriceUnitEnum
+from google.ads.googleads.v19.services.types.customer_asset_service import CustomerAssetOperation
+from google.ads.googleads.v19.resources.types.customer_asset import CustomerAsset
+from google.ads.googleads.v19.enums.types.asset_field_type import AssetFieldTypeEnum
 
 
-def main(client, customer_id):
+def main(client: GoogleAdsClient, customer_id: str) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -31,13 +42,13 @@ def main(client, customer_id):
         customer_id: a client customer ID.
     """
     # Create a new price asset.
-    price_asset_resource_name = create_price_asset(client, customer_id)
+    price_asset_resource_name: str = create_price_asset(client, customer_id)
 
     # Add the new price asset to the account.
     add_asset_to_account(client, customer_id, price_asset_resource_name)
 
 
-def create_price_asset(client, customer_id):
+def create_price_asset(client: GoogleAdsClient, customer_id: str) -> str:
     """Creates a price asset and returns its resource name.
 
     Args:
@@ -48,14 +59,14 @@ def create_price_asset(client, customer_id):
         a PriceAsset resource name.
     """
     # Create an asset operation.
-    asset_operation = client.get_type("AssetOperation")
+    asset_operation: AssetOperation = client.get_type("AssetOperation")
     # Create an asset.
-    asset = asset_operation.create
+    asset: Asset = asset_operation.create
     asset.name = f"Price Asset #{uuid4()}"
     asset.tracking_url_template = "http://tracker.example.com/?u={lpurl}"
 
     # Create the price asset.
-    price_asset = asset.price_asset
+    price_asset: PriceAsset = asset.price_asset
     price_asset.type_ = client.enums.PriceExtensionTypeEnum.SERVICES
     # Price qualifier is optional.
     price_asset.price_qualifier = (
@@ -102,7 +113,7 @@ def create_price_asset(client, customer_id):
     response = asset_service.mutate_assets(
         customer_id=customer_id, operations=[asset_operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
 
     print(f"Created a price asset with resource name '{resource_name}'.")
 
@@ -110,15 +121,15 @@ def create_price_asset(client, customer_id):
 
 
 def create_price_offering(
-    client,
-    header,
-    description,
-    final_url,
-    final_mobile_url,
-    price_in_micros,
-    currency_code,
-    unit,
-):
+    client: GoogleAdsClient,
+    header: str,
+    description: str,
+    final_url: str,
+    final_mobile_url: Optional[str],
+    price_in_micros: int,
+    currency_code: str,
+    unit: PriceExtensionPriceUnitEnum.PriceExtensionPriceUnit,
+) -> PriceOffering:
     """Creates a PriceOffering instance and returns it.
 
     Args:
@@ -134,7 +145,7 @@ def create_price_offering(
     Returns:
         A PriceOffering instance.
     """
-    price_offering = client.get_type("PriceOffering")
+    price_offering: PriceOffering = client.get_type("PriceOffering")
     price_offering.header = header
     price_offering.description = description
     price_offering.final_url = final_url
@@ -149,7 +160,9 @@ def create_price_offering(
     return price_offering
 
 
-def add_asset_to_account(client, customer_id, price_asset_resource_name):
+def add_asset_to_account(
+    client: GoogleAdsClient, customer_id: str, price_asset_resource_name: str
+) -> None:
     """Adds a new Asset to the given user account.
 
     Adding the Asset to an account allows it to serve in all campaigns under
@@ -162,9 +175,11 @@ def add_asset_to_account(client, customer_id, price_asset_resource_name):
             a PriceAsset.
     """
     # Create a customer asset operation.
-    customer_asset_operation = client.get_type("CustomerAssetOperation")
+    customer_asset_operation: CustomerAssetOperation = client.get_type(
+        "CustomerAssetOperation"
+    )
     # Create a customer asset, set its type to PRICE and attach price asset.
-    asset = customer_asset_operation.create
+    asset: CustomerAsset = customer_asset_operation.create
     asset.field_type = client.enums.AssetFieldTypeEnum.PRICE
     asset.asset = price_asset_resource_name
 
@@ -173,7 +188,7 @@ def add_asset_to_account(client, customer_id, price_asset_resource_name):
     response = customer_asset_service.mutate_customer_assets(
         customer_id=customer_id, operations=[customer_asset_operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
 
     print(
         "Created customer asset with resource name "
@@ -182,7 +197,7 @@ def add_asset_to_account(client, customer_id, price_asset_resource_name):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Add price asset for the specified customer id."
     )
     # The following argument(s) should be provided to run the example.
@@ -193,11 +208,13 @@ if __name__ == "__main__":
         required=True,
         help="The Google Ads customer ID",
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id)

--- a/examples/assets/add_sitelinks.py
+++ b/examples/assets/add_sitelinks.py
@@ -18,14 +18,23 @@ Run basic_operations/add_campaigns.py to create a campaign.
 """
 
 import argparse
+from typing import List, Sequence
 import sys
 import uuid
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.common.types.asset_types import SitelinkAsset
+from google.ads.googleads.v19.services.types.campaign_asset_service import CampaignAssetOperation
+from google.ads.googleads.v19.resources.types.campaign_asset import CampaignAsset
+from google.ads.googleads.v19.enums.types.asset_field_type import AssetFieldTypeEnum
 
 
-def main(client, customer_id, campaign_id):
+def main(
+    client: GoogleAdsClient, customer_id: str, campaign_id: str
+) -> None:
     """Adds sitelinks to a campaign using assets.
 
     Args:
@@ -34,12 +43,14 @@ def main(client, customer_id, campaign_id):
         campaign_id: The campaign to which sitelinks will be added.
     """
     # Creates sitelink assets.
-    resource_names = create_sitelink_assets(client, customer_id, campaign_id)
+    resource_names: List[str] = create_sitelink_assets(client, customer_id)
     # Associates the sitelinks at the campaign level.
     link_sitelinks_to_campaign(client, customer_id, campaign_id, resource_names)
 
 
-def create_sitelink_assets(client, customer_id):
+def create_sitelink_assets(
+    client: GoogleAdsClient, customer_id: str
+) -> List[str]:
     """Creates sitelink assets, which can be added to campaigns.
 
     Args:
@@ -49,8 +60,8 @@ def create_sitelink_assets(client, customer_id):
     Returns:
         a list of sitelink asset resource names.
     """
-    store_locator_operation = client.get_type("AssetOperation")
-    store_locator_asset = store_locator_operation.create
+    store_locator_operation: AssetOperation = client.get_type("AssetOperation")
+    store_locator_asset: Asset = store_locator_operation.create
     store_locator_asset.final_urls.append(
         "http://example.com/contact/store-finder"
     )
@@ -61,16 +72,18 @@ def create_sitelink_assets(client, customer_id):
     store_locator_asset.sitelink_asset.description2 = "Find your local store"
     store_locator_asset.sitelink_asset.link_text = "Store locator"
 
-    store_asset_operation = client.get_type("AssetOperation")
-    store_asset = store_asset_operation.create
+    store_asset_operation: AssetOperation = client.get_type("AssetOperation")
+    store_asset: Asset = store_asset_operation.create
     store_asset.final_urls.append("http://example.com/store")
     store_asset.final_mobile_urls.append("http://example.com/mobile/store")
     store_asset.sitelink_asset.description1 = "Buy some stuff"
     store_asset.sitelink_asset.description2 = "It's really good"
     store_asset.sitelink_asset.link_text = "Store"
 
-    store_addnl_asset_operation = client.get_type("AssetOperation")
-    store_addnl_asset = store_addnl_asset_operation.create
+    store_addnl_asset_operation: AssetOperation = client.get_type(
+        "AssetOperation"
+    )
+    store_addnl_asset: Asset = store_addnl_asset_operation.create
     store_addnl_asset.final_urls.append("http://example.com/store/more")
     store_addnl_asset.final_mobile_urls.append(
         "http://example.com/mobile/store/more"
@@ -89,7 +102,9 @@ def create_sitelink_assets(client, customer_id):
         ],
     )
 
-    resource_names = [result.resource_name for result in response.results]
+    resource_names: List[str] = [
+        result.resource_name for result in response.results
+    ]
 
     for resource_name in resource_names:
         print(f"Created sitelink asset with resource name '{resource_name}'.")
@@ -98,8 +113,11 @@ def create_sitelink_assets(client, customer_id):
 
 
 def link_sitelinks_to_campaign(
-    client, customer_id, campaign_id, resource_names
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    campaign_id: str,
+    resource_names: List[str],
+) -> None:
     """Creates sitelink assets, which can be added to campaigns.
 
     Args:
@@ -109,10 +127,12 @@ def link_sitelinks_to_campaign(
         resource_names: a list of sitelink asset resource names.
     """
     campaign_service = client.get_service("CampaignService")
-    operations = []
+    operations: List[CampaignAssetOperation] = []
     for resource_name in resource_names:
-        operation = client.get_type("CampaignAssetOperation")
-        campaign_asset = operation.create
+        operation: CampaignAssetOperation = client.get_type(
+            "CampaignAssetOperation"
+        )
+        campaign_asset: CampaignAsset = operation.create
         campaign_asset.asset = resource_name
         campaign_asset.campaign = campaign_service.campaign_path(
             customer_id, campaign_id
@@ -132,7 +152,7 @@ def link_sitelinks_to_campaign(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Adds sitelinks to a campaign using feed services."
     )
     # The following argument(s) should be provided to run the example.
@@ -151,11 +171,13 @@ if __name__ == "__main__":
         default=None,
         help="ID of the campaign to which sitelinks will be added.",
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id, args.campaign_id)

--- a/examples/assets/upload_image_asset.py
+++ b/examples/assets/upload_image_asset.py
@@ -19,24 +19,29 @@ To get image assets, run get_all_image_assets.py.
 
 
 import argparse
+from typing import Sequence
 import sys
 
 from examples.utils.example_helpers import get_image_bytes_from_url
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.enums.types.asset_type import AssetTypeEnum
+from google.ads.googleads.v19.enums.types.mime_type import MimeTypeEnum
 
 
 # [START upload_image_asset]
-def main(client, customer_id):
+def main(client: GoogleAdsClient, customer_id: str) -> None:
     """Main method, to run this code example as a standalone application."""
 
     # Download image from URL
-    url = "https://gaagl.page.link/Eit5"
-    image_content = get_image_bytes_from_url(url)
+    url: str = "https://gaagl.page.link/Eit5"
+    image_content: bytes = get_image_bytes_from_url(url)
 
     asset_service = client.get_service("AssetService")
-    asset_operation = client.get_type("AssetOperation")
-    asset = asset_operation.create
+    asset_operation: AssetOperation = client.get_type("AssetOperation")
+    asset: Asset = asset_operation.create
     asset.type_ = client.enums.AssetTypeEnum.IMAGE
     asset.image_asset.data = image_content
     asset.image_asset.file_size = len(image_content)
@@ -61,7 +66,7 @@ def main(client, customer_id):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Upload an image asset from a URL."
     )
     # The following argument(s) should be provided to run the example.
@@ -72,11 +77,13 @@ if __name__ == "__main__":
         required=True,
         help="The Google Ads customer ID.",
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id)


### PR DESCRIPTION
This change adds type hints and annotations to all Python files in the examples/assets directory to improve code readability and maintainability.