### PR TITLE
Add type hints to examples/advanced_operations

### DIFF
--- a/examples/advanced_operations/add_ad_customizer.py
+++ b/examples/advanced_operations/add_ad_customizer.py
@@ -36,13 +36,13 @@ def main(client, customer_id, ad_group_id):
         customer_id: a client customer ID.
         ad_group_id: an ad group ID.
     """
-    text_customizer_name = f"Planet_{uuid4().hex[:8]}"
-    price_customizer_name = f"Price_{uuid4().hex[:8]}"
+    text_customizer_name: str = f"Planet_{uuid4().hex[:8]}"
+    price_customizer_name: str = f"Price_{uuid4().hex[:8]}"
 
-    text_customizer_resource_name = create_text_customizer_attribute(
+    text_customizer_resource_name: str = create_text_customizer_attribute(
         client, customer_id, text_customizer_name
     )
-    price_customizer_resource_name = create_price_customizer_attribute(
+    price_customizer_resource_name: str = create_price_customizer_attribute(
         client, customer_id, price_customizer_name
     )
     link_customizer_attributes(
@@ -62,7 +62,7 @@ def main(client, customer_id, ad_group_id):
 
 
 # [START add_ad_customizer]
-def create_text_customizer_attribute(client, customer_id, customizer_name):
+def create_text_customizer_attribute(client: GoogleAdsClient, customer_id: str, customizer_name: str) -> str:
     """Creates a text customizer attribute and returns its resource name.
 
     Args:
@@ -88,7 +88,7 @@ def create_text_customizer_attribute(client, customer_id, customizer_name):
         customer_id=customer_id, operations=[operation]
     )
 
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(
         f"Added text customizer attribute with resource name '{resource_name}'"
     )
@@ -97,7 +97,7 @@ def create_text_customizer_attribute(client, customer_id, customizer_name):
 
 
 # [START add_ad_customizer_1]
-def create_price_customizer_attribute(client, customer_id, customizer_name):
+def create_price_customizer_attribute(client: GoogleAdsClient, customer_id: str, customizer_name: str) -> str:
     """Creates a price customizer attribute and returns its resource name.
 
     Args:
@@ -123,7 +123,7 @@ def create_price_customizer_attribute(client, customer_id, customizer_name):
         customer_id=customer_id, operations=[operation]
     )
 
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(
         f"Added price customizer attribute with resource name '{resource_name}'"
     )
@@ -133,12 +133,12 @@ def create_price_customizer_attribute(client, customer_id, customizer_name):
 
 # [START add_ad_customizer_2]
 def link_customizer_attributes(
-    client,
-    customer_id,
-    ad_group_id,
-    text_customizer_resource_name,
-    price_customizer_resource_name,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+    text_customizer_resource_name: str,
+    price_customizer_resource_name: str,
+) -> None:
     """Restricts the ad customizer attributes to work with a specific ad group.
 
     This prevents the customizer attributes from being used elsewhere and makes
@@ -192,12 +192,12 @@ def link_customizer_attributes(
 
 # [START add_ad_customizer_3]
 def create_ad_with_customizations(
-    client,
-    customer_id,
-    ad_group_id,
-    text_customizer_name,
-    price_customizer_name,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+    text_customizer_name: str,
+    price_customizer_name: str,
+) -> None:
     """Creates a responsive search ad (RSA).
 
     The RSA uses the ad customizer attributes to populate the placeholders.
@@ -255,7 +255,7 @@ def create_ad_with_customizations(
     response = ad_group_ad_service.mutate_ad_group_ads(
         customer_id=customer_id, operations=[operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(f"Added an ad with resource name '{resource_name}'")
     # [END add_ad_customizer_3]
 
@@ -287,7 +287,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(googleads_client, args.customer_id, args.ad_group_id)

--- a/examples/advanced_operations/add_ad_group_bid_modifier.py
+++ b/examples/advanced_operations/add_ad_group_bid_modifier.py
@@ -23,19 +23,24 @@ import sys
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.ad_group_bid_modifier_service import AdGroupBidModifierOperation
+from google.ads.googleads.v19.resources.types.ad_group_bid_modifier import AdGroupBidModifier
+from google.ads.googleads.v19.services.types.google_ads_service import GoogleAdsRow
+from google.ads.googleads.v19.common.types.criteria import Criterion
+from google.ads.googleads.v19.enums.types.device import DeviceEnum
 
 
 # [START add_ad_group_bid_modifier]
-def main(client, customer_id, ad_group_id, bid_modifier_value):
+def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str, bid_modifier_value: float) -> None:
     ad_group_service = client.get_service("AdGroupService")
     ad_group_bm_service = client.get_service("AdGroupBidModifierService")
 
     # Create ad group bid modifier for mobile devices with the specified ad
     # group ID and bid modifier value.
-    ad_group_bid_modifier_operation = client.get_type(
+    ad_group_bid_modifier_operation: AdGroupBidModifierOperation = client.get_type(
         "AdGroupBidModifierOperation"
     )
-    ad_group_bid_modifier = ad_group_bid_modifier_operation.create
+    ad_group_bid_modifier: AdGroupBidModifier = ad_group_bid_modifier_operation.create
 
     # Set the ad group.
     ad_group_bid_modifier.ad_group = ad_group_service.ad_group_path(
@@ -46,7 +51,7 @@ def main(client, customer_id, ad_group_id, bid_modifier_value):
     ad_group_bid_modifier.bid_modifier = bid_modifier_value
 
     # Sets the device.
-    device_enum = client.enums.DeviceEnum
+    device_enum: DeviceEnum = client.enums.DeviceEnum
     ad_group_bid_modifier.device.type_ = device_enum.MOBILE
 
     # Add the ad group bid modifier.
@@ -92,7 +97,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(

--- a/examples/advanced_operations/add_app_campaign.py
+++ b/examples/advanced_operations/add_app_campaign.py
@@ -27,17 +27,29 @@ from datetime import datetime, timedelta
 import sys
 from uuid import uuid4
 
+from typing import List
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.campaign_budget_service import CampaignBudgetOperation
+from google.ads.googleads.v19.resources.types.campaign_budget import CampaignBudget
+from google.ads.googleads.v19.services.types.campaign_service import CampaignOperation
+from google.ads.googleads.v19.resources.types.campaign import Campaign
+from google.ads.googleads.v19.services.types.campaign_criterion_service import CampaignCriterionOperation
+from google.ads.googleads.v19.resources.types.campaign_criterion import CampaignCriterion
+from google.ads.googleads.v19.services.types.ad_group_service import AdGroupOperation
+from google.ads.googleads.v19.resources.types.ad_group import AdGroup
+from google.ads.googleads.v19.services.types.ad_group_ad_service import AdGroupAdOperation
+from google.ads.googleads.v19.resources.types.ad_group_ad import AdGroupAd
+from google.ads.googleads.v19.common.types.ad_asset import AdTextAsset
 
 
-def main(client, customer_id):
+def main(client: GoogleAdsClient, customer_id: str) -> None:
     """Main function for running this example."""
     # Creates the budget for the campaign.
-    budget_resource_name = create_budget(client, customer_id)
+    budget_resource_name: str = create_budget(client, customer_id)
 
     # Creates the campaign.
-    campaign_resource_name = create_campaign(
+    campaign_resource_name: str = create_campaign(
         client, customer_id, budget_resource_name
     )
 
@@ -45,7 +57,7 @@ def main(client, customer_id):
     set_campaign_targeting_criteria(client, customer_id, campaign_resource_name)
 
     # Creates an Ad Group.
-    ad_group_resource_name = create_ad_group(
+    ad_group_resource_name: str = create_ad_group(
         client, customer_id, campaign_resource_name
     )
 
@@ -53,7 +65,7 @@ def main(client, customer_id):
     create_app_ad(client, customer_id, ad_group_resource_name)
 
 
-def create_budget(client, customer_id):
+def create_budget(client: GoogleAdsClient, customer_id: str) -> str:
     """Creates a budget under the given customer ID.
 
     Args:
@@ -66,9 +78,9 @@ def create_budget(client, customer_id):
     # Retrieves the campaign budget service.
     campaign_budget_service = client.get_service("CampaignBudgetService")
     # Retrieves a new campaign budget operation object.
-    campaign_budget_operation = client.get_type("CampaignBudgetOperation")
+    campaign_budget_operation: CampaignBudgetOperation = client.get_type("CampaignBudgetOperation")
     # Creates a campaign budget.
-    campaign_budget = campaign_budget_operation.create
+    campaign_budget: CampaignBudget = campaign_budget_operation.create
     campaign_budget.name = f"Interplanetary Cruise #{uuid4()}"
     campaign_budget.amount_micros = 50000000
     campaign_budget.delivery_method = (
@@ -82,12 +94,12 @@ def create_budget(client, customer_id):
     response = campaign_budget_service.mutate_campaign_budgets(
         customer_id=customer_id, operations=[campaign_budget_operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(f'Created campaign budget with resource_name: "{resource_name}"')
     return resource_name
 
 
-def create_campaign(client, customer_id, budget_resource_name):
+def create_campaign(client: GoogleAdsClient, customer_id: str, budget_resource_name: str) -> str:
     """Creates an app campaign under the given customer ID.
 
     Args:
@@ -99,8 +111,8 @@ def create_campaign(client, customer_id, budget_resource_name):
         A resource_name str for the newly created app campaign.
     """
     campaign_service = client.get_service("CampaignService")
-    campaign_operation = client.get_type("CampaignOperation")
-    campaign = campaign_operation.create
+    campaign_operation: CampaignOperation = client.get_type("CampaignOperation")
+    campaign: Campaign = campaign_operation.create
     campaign.name = f"Interplanetary Cruise App #{uuid4()}"
     campaign.campaign_budget = budget_resource_name
     # Recommendation: Set the campaign to PAUSED when creating it to
@@ -150,14 +162,14 @@ def create_campaign(client, customer_id, budget_resource_name):
     campaign_response = campaign_service.mutate_campaigns(
         customer_id=customer_id, operations=[campaign_operation]
     )
-    resource_name = campaign_response.results[0].resource_name
+    resource_name: str = campaign_response.results[0].resource_name
     print(f'Created App campaign with resource name: "{resource_name}".')
     return resource_name
 
 
 def set_campaign_targeting_criteria(
-    client, customer_id, campaign_resource_name
-):
+    client: GoogleAdsClient, customer_id: str, campaign_resource_name: str
+) -> None:
     """Sets campaign targeting criteria for a given campaign.
 
     Both location and language targeting are illustrated.
@@ -171,17 +183,17 @@ def set_campaign_targeting_criteria(
     geo_target_constant_service = client.get_service("GeoTargetConstantService")
     googleads_service = client.get_service("GoogleAdsService")
 
-    campaign_criterion_operations = []
+    campaign_criterion_operations: List[CampaignCriterionOperation] = []
     # Creates the location campaign criteria.
     # Besides using location_id, you can also search by location names from
     # GeoTargetConstantService.suggest_geo_target_constants() and directly
     # apply GeoTargetConstant.resource_name here. An example can be found
     # in targeting/get_geo_target_constant_by_names.py.
     for location_id in ["21137", "2484"]:  # California  # Mexico
-        campaign_criterion_operation = client.get_type(
+        campaign_criterion_operation: CampaignCriterionOperation = client.get_type(
             "CampaignCriterionOperation"
         )
-        campaign_criterion = campaign_criterion_operation.create
+        campaign_criterion: CampaignCriterion = campaign_criterion_operation.create
         campaign_criterion.campaign = campaign_resource_name
         campaign_criterion.location.geo_target_constant = (
             geo_target_constant_service.geo_target_constant_path(location_id)
@@ -190,10 +202,10 @@ def set_campaign_targeting_criteria(
 
     # Creates the language campaign criteria.
     for language_id in ["1000", "1003"]:  # English  # Spanish
-        campaign_criterion_operation = client.get_type(
+        campaign_criterion_operation: CampaignCriterionOperation = client.get_type(
             "CampaignCriterionOperation"
         )
-        campaign_criterion = campaign_criterion_operation.create
+        campaign_criterion: CampaignCriterion = campaign_criterion_operation.create
         campaign_criterion.campaign = campaign_resource_name
         campaign_criterion.language.language_constant = (
             googleads_service.language_constant_path(language_id)
@@ -210,7 +222,7 @@ def set_campaign_targeting_criteria(
         )
 
 
-def create_ad_group(client, customer_id, campaign_resource_name):
+def create_ad_group(client: GoogleAdsClient, customer_id: str, campaign_resource_name: str) -> str:
     """Creates an ad group for a given campaign.
 
     Args:
@@ -228,8 +240,8 @@ def create_ad_group(client, customer_id, campaign_resource_name):
     # Since the advertising_channel_sub_type is APP_CAMPAIGN,
     #   1- you cannot override bid settings at the ad group level.
     #   2- you cannot add ad group criteria.
-    ad_group_operation = client.get_type("AdGroupOperation")
-    ad_group = ad_group_operation.create
+    ad_group_operation: AdGroupOperation = client.get_type("AdGroupOperation")
+    ad_group: AdGroup = ad_group_operation.create
     ad_group.name = f"Earth to Mars cruises {uuid4()}"
     ad_group.status = client.enums.AdGroupStatusEnum.ENABLED
     ad_group.campaign = campaign_resource_name
@@ -238,12 +250,12 @@ def create_ad_group(client, customer_id, campaign_resource_name):
         customer_id=customer_id, operations=[ad_group_operation]
     )
 
-    ad_group_resource_name = ad_group_response.results[0].resource_name
+    ad_group_resource_name: str = ad_group_response.results[0].resource_name
     print(f'Ad Group created with resource name: "{ad_group_resource_name}".')
     return ad_group_resource_name
 
 
-def create_app_ad(client, customer_id, ad_group_resource_name):
+def create_app_ad(client: GoogleAdsClient, customer_id: str, ad_group_resource_name: str) -> None:
     """Creates an App ad for a given ad group.
 
     Args:
@@ -253,8 +265,8 @@ def create_app_ad(client, customer_id, ad_group_resource_name):
     """
     # Creates the ad group ad.
     ad_group_ad_service = client.get_service("AdGroupAdService")
-    ad_group_ad_operation = client.get_type("AdGroupAdOperation")
-    ad_group_ad = ad_group_ad_operation.create
+    ad_group_ad_operation: AdGroupAdOperation = client.get_type("AdGroupAdOperation")
+    ad_group_ad: AdGroupAd = ad_group_ad_operation.create
     ad_group_ad.status = client.enums.AdGroupAdStatusEnum.ENABLED
     ad_group_ad.ad_group = ad_group_resource_name
     # ad_data is a 'oneof' message so setting app_ad
@@ -279,15 +291,15 @@ def create_app_ad(client, customer_id, ad_group_resource_name):
     ad_group_ad_response = ad_group_ad_service.mutate_ad_group_ads(
         customer_id=customer_id, operations=[ad_group_ad_operation]
     )
-    ad_group_ad_resource_name = ad_group_ad_response.results[0].resource_name
+    ad_group_ad_resource_name: str = ad_group_ad_response.results[0].resource_name
     print(
         "Ad Group App Ad created with resource name:"
         f'"{ad_group_ad_resource_name}".'
     )
 
 
-def create_ad_text_asset(client, text):
-    ad_text_asset = client.get_type("AdTextAsset")
+def create_ad_text_asset(client: GoogleAdsClient, text: str) -> AdTextAsset:
+    ad_text_asset: AdTextAsset = client.get_type("AdTextAsset")
     ad_text_asset.text = text
     return ad_text_asset
 
@@ -310,7 +322,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(googleads_client, args.customer_id)

--- a/examples/advanced_operations/add_bidding_data_exclusion.py
+++ b/examples/advanced_operations/add_bidding_data_exclusion.py
@@ -28,9 +28,11 @@ from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.bidding_data_exclusion_service import BiddingDataExclusionOperation
+from google.ads.googleads.v19.resources.types.bidding_data_exclusion import BiddingDataExclusion
 
 
-def main(client, customer_id, start_date_time, end_date_time):
+def main(client: GoogleAdsClient, customer_id: str, start_date_time: str, end_date_time: str) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -43,8 +45,8 @@ def main(client, customer_id, start_date_time, end_date_time):
     bidding_data_exclusion_service = client.get_service(
         "BiddingDataExclusionService"
     )
-    operation = client.get_type("BiddingDataExclusionOperation")
-    bidding_data_exclusion = operation.create
+    operation: BiddingDataExclusionOperation = client.get_type("BiddingDataExclusionOperation")
+    bidding_data_exclusion: BiddingDataExclusion = operation.create
     # A unique name is required for every data exclusion
     bidding_data_exclusion.name = f"Data exclusion #{uuid4()}"
     # The CHANNEL scope applies the data exclusion to all campaigns of specific
@@ -71,7 +73,7 @@ def main(client, customer_id, start_date_time, end_date_time):
         customer_id=customer_id, operations=[operation]
     )
 
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
 
     print(f"Added data exclusion with resource name: '{resource_name}'")
     # [END add_bidding_data_exclusion]
@@ -111,7 +113,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(

--- a/examples/advanced_operations/add_bidding_seasonality_adjustment.py
+++ b/examples/advanced_operations/add_bidding_seasonality_adjustment.py
@@ -28,15 +28,17 @@ from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.bidding_seasonality_adjustment_service import BiddingSeasonalityAdjustmentOperation
+from google.ads.googleads.v19.resources.types.bidding_seasonality_adjustment import BiddingSeasonalityAdjustment
 
 
 def main(
-    client,
-    customer_id,
-    start_date_time,
-    end_date_time,
-    conversion_rate_modifier,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    start_date_time: str,
+    end_date_time: str,
+    conversion_rate_modifier: float,
+) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -51,8 +53,8 @@ def main(
     bidding_seasonality_adjustment_service = client.get_service(
         "BiddingSeasonalityAdjustmentService"
     )
-    operation = client.get_type("BiddingSeasonalityAdjustmentOperation")
-    bidding_seasonality_adjustment = operation.create
+    operation: BiddingSeasonalityAdjustmentOperation = client.get_type("BiddingSeasonalityAdjustmentOperation")
+    bidding_seasonality_adjustment: BiddingSeasonalityAdjustment = operation.create
     # A unique name is required for every seasonality adjustment.
     bidding_seasonality_adjustment.name = f"Seasonality adjustment #{uuid4()}"
     # The CHANNEL scope applies the conversion_rate_modifier to all campaigns of
@@ -85,7 +87,7 @@ def main(
         customer_id=customer_id, operations=[operation]
     )
 
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
 
     print(f"Added seasonality adjustment with resource name: '{resource_name}'")
     # [END add_bidding_seasonality_adjustment]
@@ -133,7 +135,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(

--- a/examples/advanced_operations/add_call_ad.py
+++ b/examples/advanced_operations/add_call_ad.py
@@ -24,22 +24,26 @@ To get ad group IDs, run basic_operations/get_ad_groups.py.
 import argparse
 import sys
 
+from typing import Optional
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.ad_group_ad_service import AdGroupAdOperation
+from google.ads.googleads.v19.resources.types.ad_group_ad import AdGroupAd
+from google.ads.googleads.v19.resources.types.ad import Ad
 
 # Country code is a two-letter ISO-3166 code, for a list of all codes see:
 # https://developers.google.com/google-ads/api/reference/data/codes-formats#expandable-17
-_DEFAULT_PHONE_COUNTRY = "US"
+_DEFAULT_PHONE_COUNTRY: str = "US"
 
 
 def main(
-    client,
-    customer_id,
-    ad_group_id,
-    phone_number,
-    phone_country,
-    conversion_action_id,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+    phone_number: str,
+    phone_country: str,
+    conversion_action_id: Optional[str],
+) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -51,13 +55,13 @@ def main(
         conversion_action_id: an ID for a conversion action.
     """
     googleads_service = client.get_service("GoogleAdsService")
-    operation = client.get_type("AdGroupAdOperation")
-    ad_group_ad = operation.create
+    operation: AdGroupAdOperation = client.get_type("AdGroupAdOperation")
+    ad_group_ad: AdGroupAd = operation.create
     ad_group_ad.ad_group = googleads_service.ad_group_path(
         customer_id, ad_group_id
     )
     ad_group_ad.status = client.enums.AdGroupAdStatusEnum.PAUSED
-    ad = ad_group_ad.ad
+    ad: Ad = ad_group_ad.ad
     # The URL of the webpage to refer to.
     ad.final_urls.append("https://www.example.com")
     # Sets basic information.
@@ -94,7 +98,7 @@ def main(
     response = ad_group_ad_service.mutate_ad_group_ads(
         customer_id=customer_id, operations=[operation]
     )
-    resource_name = response.results[0].resource_name
+    resource_name: str = response.results[0].resource_name
     print(f"Created ad group ad with resource name: '{resource_name}'")
 
 
@@ -146,7 +150,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(

--- a/examples/advanced_operations/add_demand_gen_campaign.py
+++ b/examples/advanced_operations/add_demand_gen_campaign.py
@@ -22,22 +22,31 @@ import sys
 from uuid import uuid4
 
 from examples.utils.example_helpers import get_image_bytes_from_url
+from typing import List
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.google_ads_service import MutateOperation
+from google.ads.googleads.v19.resources.types.campaign_budget import CampaignBudget
+from google.ads.googleads.v19.resources.types.campaign import Campaign
+from google.ads.googleads.v19.resources.types.ad_group import AdGroup
+from google.ads.googleads.v19.resources.types.ad_group_ad import AdGroupAd
+from google.ads.googleads.v19.resources.types.ad import Ad
+from google.ads.googleads.v19.common.types.ad_asset import AdVideoAsset, AdImageAsset, AdTextAsset
+from google.ads.googleads.v19.resources.types.asset import Asset
 
 # Temporary IDs for resources.
-BUDGET_TEMPORARY_ID = -1
-CAMPAIGN_TEMPORARY_ID = -2
-AD_GROUP_TEMPORARY_ID = -3
-VIDEO_ASSET_TEMPORARY_ID = -4
-LOGO_ASSET_TEMPORARY_ID = -5
+BUDGET_TEMPORARY_ID: int = -1
+CAMPAIGN_TEMPORARY_ID: int = -2
+AD_GROUP_TEMPORARY_ID: int = -3
+VIDEO_ASSET_TEMPORARY_ID: int = -4
+LOGO_ASSET_TEMPORARY_ID: int = -5
 
 # URLs for assets
-DEFAULT_LOGO_IMAGE_URL = "https://gaagl.page.link/bjYi"
-DEFAULT_FINAL_URL = "http://example.com/demand_gen"
+DEFAULT_LOGO_IMAGE_URL: str = "https://gaagl.page.link/bjYi"
+DEFAULT_FINAL_URL: str = "http://example.com/demand_gen"
 
 
-def main(client: GoogleAdsClient, customer_id: str, video_id: str):
+def main(client: GoogleAdsClient, customer_id: str, video_id: str) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -47,19 +56,19 @@ def main(client: GoogleAdsClient, customer_id: str, video_id: str):
     """
     googleads_service = client.get_service("GoogleAdsService")
 
-    budget_resource_name = googleads_service.campaign_budget_path(
+    budget_resource_name: str = googleads_service.campaign_budget_path(
         customer_id, BUDGET_TEMPORARY_ID
     )
-    campaign_resource_name = googleads_service.campaign_path(
+    campaign_resource_name: str = googleads_service.campaign_path(
         customer_id, CAMPAIGN_TEMPORARY_ID
     )
-    ad_group_resource_name = googleads_service.ad_group_path(
+    ad_group_resource_name: str = googleads_service.ad_group_path(
         customer_id, AD_GROUP_TEMPORARY_ID
     )
-    video_asset_resource_name = googleads_service.asset_path(
+    video_asset_resource_name: str = googleads_service.asset_path(
         customer_id, VIDEO_ASSET_TEMPORARY_ID
     )
-    logo_asset_resource_name = googleads_service.asset_path(
+    logo_asset_resource_name: str = googleads_service.asset_path(
         customer_id, LOGO_ASSET_TEMPORARY_ID
     )
 
@@ -71,7 +80,7 @@ def main(client: GoogleAdsClient, customer_id: str, video_id: str):
     # single Mutate request; the entities will either all complete successfully
     # or fail entirely, leaving no orphaned entities. See:
     # https://developers.google.com/google-ads/api/docs/mutating/overview
-    mutate_operations = [
+    mutate_operations: List[MutateOperation] = [
         # It's important to create these entities in this order because they
         # depend on each other, for example the ad group depends on the
         # campaign, and the ad group ad depends on the ad group.
@@ -105,7 +114,7 @@ def main(client: GoogleAdsClient, customer_id: str, video_id: str):
 
 def create_campaign_budget_operation(
     client: GoogleAdsClient, budget_resource_name: str
-):
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new CampaignBudget.
 
     A temporary ID will be assigned to this campaign budget so that it can be
@@ -118,9 +127,9 @@ def create_campaign_budget_operation(
     Returns:
         A MutateOperation for creating a CampaignBudget.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     campaign_budget_operation = mutate_operation.campaign_budget_operation
-    campaign_budget = campaign_budget_operation.create
+    campaign_budget: CampaignBudget = campaign_budget_operation.create
     campaign_budget.name = f"Demand Gen campaign budget {uuid4()}"
     # The budget period already defaults to DAILY.
     campaign_budget.amount_micros = 50_000_000
@@ -141,7 +150,7 @@ def create_demand_gen_campaign_operation(
     client: GoogleAdsClient,
     campaign_resource_name: str,
     budget_resource_name: str,
-):
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new Campaign.
 
     A temporary ID will be assigned to this campaign so that it can be
@@ -155,9 +164,9 @@ def create_demand_gen_campaign_operation(
     Returns:
         A MutateOperation for creating a Campaign.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     campaign_operation = mutate_operation.campaign_operation
-    campaign = campaign_operation.create
+    campaign: Campaign = campaign_operation.create
     campaign.name = f"Demand Gen #{uuid4()}"
     # Set the campaign status as PAUSED. The campaign is the only entity in the
     # mutate request that should have its status set.
@@ -184,7 +193,7 @@ def create_ad_group_operation(
     client: GoogleAdsClient,
     ad_group_resource_name: str,
     campaign_resource_name: str,
-):
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new AdGroup.
 
     Args:
@@ -196,10 +205,10 @@ def create_ad_group_operation(
     Returns:
         A MutateOperation for creating an AdGroup.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     ad_group_operation = mutate_operation.ad_group_operation
     # Creates an ad group.
-    ad_group = ad_group_operation.create
+    ad_group: AdGroup = ad_group_operation.create
     ad_group.resource_name = ad_group_resource_name
     ad_group.name = f"Earth to Mars Cruises #{uuid4()}"
     ad_group.status = client.enums.AdGroupStatusEnum.ENABLED
@@ -229,7 +238,7 @@ def create_asset_operations(
     video_asset_resource_name: str,
     video_id: str,
     logo_asset_resource_name: str,
-):
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that create new Assets.
 
     Args:
@@ -261,7 +270,7 @@ def create_demand_gen_ad_operation(
     ad_group_resource_name: str,
     video_asset_resource_name: str,
     logo_asset_resource_name: str,
-):
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new Demand Gen Ad.
 
     Args:
@@ -273,13 +282,13 @@ def create_demand_gen_ad_operation(
     Returns:
         A MutateOperation for creating an AdGroupAd.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     ad_group_ad_operation = mutate_operation.ad_group_ad_operation
-    ad_group_ad = ad_group_ad_operation.create
+    ad_group_ad: AdGroupAd = ad_group_ad_operation.create
     ad_group_ad.ad_group = ad_group_resource_name
     ad_group_ad.status = client.enums.AdGroupAdStatusEnum.ENABLED
 
-    ad = ad_group_ad.ad
+    ad: Ad = ad_group_ad.ad
     ad.name = "Demand gen multi asset ad"
     ad.final_urls.append(DEFAULT_FINAL_URL)
 
@@ -290,27 +299,27 @@ def create_demand_gen_ad_operation(
     # that would require creating another asset.
 
     # Create AssetLink for video
-    video_asset_link = client.get_type("AdVideoAsset")
+    video_asset_link: AdVideoAsset = client.get_type("AdVideoAsset")
     video_asset_link.asset = video_asset_resource_name
     demand_gen_ad.videos.append(video_asset_link)
 
     # Create AssetLink for logo
-    logo_image_asset_link = client.get_type("AdImageAsset")
+    logo_image_asset_link: AdImageAsset = client.get_type("AdImageAsset")
     logo_image_asset_link.asset = logo_asset_resource_name
     demand_gen_ad.logo_images.append(logo_image_asset_link)
 
     # Create AssetLink for headline
-    headline_asset_link = client.get_type("AdTextAsset")
+    headline_asset_link: AdTextAsset = client.get_type("AdTextAsset")
     headline_asset_link.text = "Interplanetary cruises"
     demand_gen_ad.headlines.append(headline_asset_link)
 
     # Create AssetLink for long headline
-    long_headline_asset_link = client.get_type("AdTextAsset")
+    long_headline_asset_link: AdTextAsset = client.get_type("AdTextAsset")
     long_headline_asset_link.text = "Travel the World"
     demand_gen_ad.long_headlines.append(long_headline_asset_link)
 
     # Create AssetLink for description
-    description_asset_link = client.get_type("AdTextAsset")
+    description_asset_link: AdTextAsset = client.get_type("AdTextAsset")
     description_asset_link.text = "Book now for an extra discount"
     demand_gen_ad.descriptions.append(description_asset_link)
 
@@ -320,7 +329,7 @@ def create_demand_gen_ad_operation(
 
 def create_image_asset_operation(
     client: GoogleAdsClient, asset_resource_name: str, url: str, asset_name: str
-):
+) -> MutateOperation:
     """Creates a MutateOperation for a new image asset.
 
     Args:
@@ -332,9 +341,9 @@ def create_image_asset_operation(
     Returns:
         A MutateOperation for creating an image asset.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     asset_operation = mutate_operation.asset_operation
-    asset = asset_operation.create
+    asset: Asset = asset_operation.create
     asset.resource_name = asset_resource_name
     # Provide a unique friendly name to identify your asset. When there is an
     # existing image asset with the same content but a different name, the new
@@ -351,7 +360,7 @@ def create_video_asset_operation(
     asset_resource_name: str,
     video_id: str,
     asset_name: str,
-):
+) -> MutateOperation:
     """Creates a MutateOperation for a new video asset.
 
     Args:
@@ -363,9 +372,9 @@ def create_video_asset_operation(
     Returns:
         A MutateOperation for creating a video asset.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     asset_operation = mutate_operation.asset_operation
-    asset = asset_operation.create
+    asset: Asset = asset_operation.create
     asset.resource_name = asset_resource_name
     asset.name = asset_name
     asset.type_ = client.enums.AssetTypeEnum.YOUTUBE_VIDEO
@@ -395,7 +404,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(googleads_client, args.customer_id, args.video_id)

--- a/examples/advanced_operations/add_display_upload_ad.py
+++ b/examples/advanced_operations/add_display_upload_ad.py
@@ -25,12 +25,17 @@ import requests
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v19.services.types.asset_service import AssetOperation
+from google.ads.googleads.v19.resources.types.asset import Asset
+from google.ads.googleads.v19.services.types.ad_group_ad_service import AdGroupAdOperation
+from google.ads.googleads.v19.resources.types.ad_group_ad import AdGroupAd
+from google.ads.googleads.v19.resources.types.ad import Ad
 
 
-BUNDLE_URL = "https://gaagl.page.link/ib87"
+BUNDLE_URL: str = "https://gaagl.page.link/ib87"
 
 
-def main(client, customer_id, ad_group_id):
+def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str) -> None:
     """Adds a display upload ad to a given ad group.
 
     Args:
@@ -46,7 +51,7 @@ def main(client, customer_id, ad_group_id):
     # https://developers.google.com/google-ads/api/reference/rpc/latest/DisplayUploadAdInfo
 
     # Creates a new media bundle asset and returns the resource name.
-    ad_asset_resource_name = create_media_bundle_asset(client, customer_id)
+    ad_asset_resource_name: str = create_media_bundle_asset(client, customer_id)
 
     # Creates a new display upload ad and associates it with the specified
     # ad group.
@@ -55,7 +60,7 @@ def main(client, customer_id, ad_group_id):
     )
 
 
-def create_media_bundle_asset(client, customer_id):
+def create_media_bundle_asset(client: GoogleAdsClient, customer_id: str) -> str:
     """Creates a media bundle from the assets in a zip file.
 
     The zip file contains the HTML5 components.
@@ -70,8 +75,8 @@ def create_media_bundle_asset(client, customer_id):
     asset_service = client.get_service("AssetService")
 
     # Construct an asset operation and populate its fields.
-    asset_operation = client.get_type("AssetOperation")
-    media_bundle_asset = asset_operation.create
+    asset_operation: AssetOperation = client.get_type("AssetOperation")
+    media_bundle_asset: Asset = asset_operation.create
     media_bundle_asset.type_ = client.enums.AssetTypeEnum.MEDIA_BUNDLE
     media_bundle_asset.name = "Ad Media Bundle"
     # The HTML5 zip file contains all the HTML, CSS, and images needed for the
@@ -88,7 +93,7 @@ def create_media_bundle_asset(client, customer_id):
     )
 
     # Display and return the resulting resource name.
-    uploaded_asset_resource_name = mutate_asset_response.results[
+    uploaded_asset_resource_name: str = mutate_asset_response.results[
         0
     ].resource_name
     print(f"Uploaded file with resource name '{uploaded_asset_resource_name}'.")
@@ -97,8 +102,8 @@ def create_media_bundle_asset(client, customer_id):
 
 
 def create_display_upload_ad_group_ad(
-    client, customer_id, ad_group_id, ad_asset_resource_name
-):
+    client: GoogleAdsClient, customer_id: str, ad_group_id: str, ad_asset_resource_name: str
+) -> None:
     """Creates a new HTML5 display upload ad and adds it to the given ad group.
 
     Args:
@@ -112,17 +117,17 @@ def create_display_upload_ad_group_ad(
     ad_group_ad_service = client.get_service("AdGroupAdService")
 
     # Create an AdGroupAdOperation.
-    ad_group_ad_operation = client.get_type("AdGroupAdOperation")
+    ad_group_ad_operation: AdGroupAdOperation = client.get_type("AdGroupAdOperation")
 
     # Configure the ad group ad fields.
-    ad_group_ad = ad_group_ad_operation.create
+    ad_group_ad: AdGroupAd = ad_group_ad_operation.create
     ad_group_ad.status = client.enums.AdGroupAdStatusEnum.PAUSED
     ad_group_ad.ad_group = client.get_service("AdGroupService").ad_group_path(
         customer_id, ad_group_id
     )
 
     # Configured the ad as a display upload ad.
-    display_upload_ad = ad_group_ad.ad
+    display_upload_ad: Ad = ad_group_ad.ad
     display_upload_ad.name = "Ad for HTML5"
     display_upload_ad.final_urls.append("http://example.com/html5")
     # Exactly one of the ad_data "oneof" fields must be included to specify the
@@ -170,7 +175,7 @@ if __name__ == "__main__":
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(version="v19")
 
     try:
         main(googleads_client, args.customer_id, args.ad_group_id)


### PR DESCRIPTION
This commit adds type hints to the following files:
- examples/advanced_operations/__init__.py (no changes as file was empty)
- examples/advanced_operations/add_ad_customizer.py
- examples/advanced_operations/add_ad_group_bid_modifier.py
- examples/advanced_operations/add_app_campaign.py
- examples/advanced_operations/add_bidding_data_exclusion.py
- examples/advanced_operations/add_bidding_seasonality_adjustment.py
- examples/advanced_operations/add_call_ad.py
- examples/advanced_operations/add_demand_gen_campaign.py
- examples/advanced_operations/add_display_upload_ad.py

This is part of a larger effort to add type hints to all files in the examples/advanced_operations directory. The remaining files will be updated in subsequent commits.