### PR TITLE
Add type hints to examples/billing

### DIFF
--- a/examples/billing/add_account_budget_proposal.py
+++ b/examples/billing/add_account_budget_proposal.py
@@ -27,7 +27,9 @@ from google.ads.googleads.errors import GoogleAdsException
 
 
 # [START add_account_budget_proposal]
-def main(client, customer_id, billing_setup_id):
+def main(
+    client: GoogleAdsClient, customer_id: str, billing_setup_id: str
+):
     account_budget_proposal_service = client.get_service(
         "AccountBudgetProposalService"
     )

--- a/examples/billing/add_billing_setup.py
+++ b/examples/billing/add_billing_setup.py
@@ -27,6 +27,7 @@ manager account and is linked to a customer account via a billing setup.
 import argparse
 from datetime import datetime, timedelta
 import sys
+from typing import Any, Optional
 from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -34,7 +35,10 @@ from google.ads.googleads.errors import GoogleAdsException
 
 
 def main(
-    client, customer_id, payments_account_id=None, payments_profile_id=None
+    client: GoogleAdsClient,
+    customer_id: str,
+    payments_account_id: Optional[str] = None,
+    payments_profile_id: Optional[str] = None,
 ):
     """The main method that creates all necessary entities for the example.
 
@@ -64,8 +68,11 @@ def main(
 
 
 def create_billing_setup(
-    client, customer_id, payments_account_id=None, payments_profile_id=None
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    payments_account_id: Optional[str] = None,
+    payments_profile_id: Optional[str] = None,
+) -> Any:
     """Creates and returns a new billing setup instance.
 
     The new billing setup will have its payment details populated. One of the
@@ -109,7 +116,9 @@ def create_billing_setup(
     return billing_setup
 
 
-def set_billing_setup_date_times(client, customer_id, billing_setup):
+def set_billing_setup_date_times(
+    client: GoogleAdsClient, customer_id: str, billing_setup: Any
+):
     """Sets the starting and ending date times for the new billing setup.
 
     Queries the customer's account to see if there are any approved billing

--- a/examples/billing/get_invoices.py
+++ b/examples/billing/get_invoices.py
@@ -18,12 +18,13 @@
 import argparse
 from datetime import date, timedelta
 import sys
+from typing import Any, Optional
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
 
 
-def main(client, customer_id, billing_setup_id):
+def main(client: GoogleAdsClient, customer_id: str, billing_setup_id: str):
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -100,7 +101,7 @@ def main(client, customer_id, billing_setup_id):
             # [END get_invoices_1]
 
 
-def micros_to_currency(micros):
+def micros_to_currency(micros: Optional[int]) -> Optional[float]:
     return micros / 1000000.0 if micros is not None else None
 
 


### PR DESCRIPTION
This change adds type annotations and hints to the Python files in the examples/billing directory to improve code readability and maintainability.

Type hints were added to function arguments and return values for:
- add_account_budget_proposal.py
- add_billing_setup.py
- get_invoices.py