### PR TITLE
Add type hints to examples/shopping_ads

### DIFF
--- a/examples/shopping_ads/__init__.py
+++ b/examples/shopping_ads/__init__.py
@@ -1,0 +1,1 @@
+# Fully type-hinted

--- a/examples/shopping_ads/add_listing_scope.py
+++ b/examples/shopping_ads/add_listing_scope.py
@@ -29,15 +29,43 @@ scopes before running this example.
 
 import argparse
 import sys
+from typing import Any, List
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v17.common.types.criteria import (
+    ListingDimensionInfo,
+)
+from google.ads.googleads.v17.enums.types.product_custom_attribute_index import (
+    ProductCustomAttributeIndexEnum,
+)
+from google.ads.googleads.v17.enums.types.product_type_level import (
+    ProductTypeLevelEnum,
+)
+from google.ads.googleads.v17.resources.types.campaign_criterion import (
+    CampaignCriterion,
+)
+from google.ads.googleads.v17.services.services.campaign_criterion_service import (
+    CampaignCriterionServiceClient,
+)
+from google.ads.googleads.v17.services.services.campaign_service import (
+    CampaignServiceClient,
+)
+from google.ads.googleads.v17.services.types.campaign_criterion_operation import (
+    CampaignCriterionOperation,
+)
 
 
-def main(client, customer_id, campaign_id):
-    campaign_service = client.get_service("CampaignService")
-    campaign_criterion_operation = client.get_type("CampaignCriterionOperation")
-    campaign_criterion = campaign_criterion_operation.create
+def main(
+    client: GoogleAdsClient, customer_id: str, campaign_id: str
+) -> None:
+    campaign_service: CampaignServiceClient = client.get_service(
+        "CampaignService"
+    )
+    campaign_criterion_operation: CampaignCriterionOperation = client.get_type(
+        "CampaignCriterionOperation"
+    )
+    campaign_criterion: CampaignCriterion = campaign_criterion_operation.create
     campaign_criterion.campaign = campaign_service.campaign_path(
         customer_id, campaign_id
     )
@@ -47,16 +75,22 @@ def main(client, customer_id, campaign_id):
     # must be met for a product to be included in a campaign.
     # A typical listing scope might only have a few dimensions. This example
     # demonstrates a range of different dimensions you could use.
-    dimensions = campaign_criterion.listing_scope.dimensions
+    dimensions: List[ListingDimensionInfo] = (
+        campaign_criterion.listing_scope.dimensions
+    )
 
-    product_brand_dimension = client.get_type("ListingDimensionInfo")
+    product_brand_dimension: ListingDimensionInfo = client.get_type(
+        "ListingDimensionInfo"
+    )
     product_brand_dimension.product_brand.value = "google"
     dimensions.append(product_brand_dimension)
 
-    product_custom_attribute_index_enum = (
+    product_custom_attribute_index_enum: ProductCustomAttributeIndexEnum = (
         client.enums.ProductCustomAttributeIndexEnum
     )
-    product_custom_attribute_dimension = client.get_type("ListingDimensionInfo")
+    product_custom_attribute_dimension: ListingDimensionInfo = client.get_type(
+        "ListingDimensionInfo"
+    )
     product_custom_attribute = (
         product_custom_attribute_dimension.product_custom_attribute
     )
@@ -64,22 +98,30 @@ def main(client, customer_id, campaign_id):
     product_custom_attribute.value = "top_selling_products"
     dimensions.append(product_custom_attribute_dimension)
 
-    product_type_level_enum = client.enums.ProductTypeLevelEnum
-    product_type_dimension_1 = client.get_type("ListingDimensionInfo")
+    product_type_level_enum: ProductTypeLevelEnum = (
+        client.enums.ProductTypeLevelEnum
+    )
+    product_type_dimension_1: ListingDimensionInfo = client.get_type(
+        "ListingDimensionInfo"
+    )
     product_type = product_type_dimension_1.product_type
     product_type.level = product_type_level_enum.LEVEL1
     product_type.value = "electronics"
     dimensions.append(product_type_dimension_1)
 
-    product_type_dimension_2 = client.get_type("ListingDimensionInfo")
+    product_type_dimension_2: ListingDimensionInfo = client.get_type(
+        "ListingDimensionInfo"
+    )
     product_type = product_type_dimension_2.product_type
     product_type.level = product_type_level_enum.LEVEL2
     product_type.value = "smartphones"
     dimensions.append(product_type_dimension_2)
 
-    campaign_criterion_service = client.get_service("CampaignCriterionService")
+    campaign_criterion_service: CampaignCriterionServiceClient = (
+        client.get_service("CampaignCriterionService")
+    )
 
-    campaign_criterion_response = (
+    campaign_criterion_response: Any = (
         campaign_criterion_service.mutate_campaign_criteria(
             customer_id=customer_id, operations=[campaign_criterion_operation]
         )
@@ -89,8 +131,8 @@ def main(client, customer_id, campaign_id):
         f"Added {len(campaign_criterion_response.results)} campaign "
         "criteria:"
     )
-    for campaign_criterion in campaign_criterion_response.results:
-        print(campaign_criterion.resource_name)
+    for criterion in campaign_criterion_response.results:
+        print(criterion.resource_name)
 
 
 if __name__ == "__main__":
@@ -108,11 +150,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "-i", "--campaign_id", type=str, required=True, help="The campaign ID."
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id, args.campaign_id)

--- a/examples/shopping_ads/add_performance_max_retail_campaign.py
+++ b/examples/shopping_ads/add_performance_max_retail_campaign.py
@@ -38,6 +38,7 @@ Prerequisites:
 import argparse
 from datetime import datetime, timedelta
 import sys
+from typing import Any, Dict, List, Tuple
 from uuid import uuid4
 
 from examples.utils.example_helpers import get_image_bytes_from_url
@@ -45,7 +46,93 @@ from google.api_core import protobuf_helpers
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
 from google.ads.googleads.util import convert_snake_case_to_upper_case
-
+from google.ads.googleads.v17.common.types.criteria import LanguageInfo
+from google.ads.googleads.v17.common.types.asset_types import (
+    ImageAsset,
+    TextAsset,
+)
+from google.ads.googleads.v17.enums.types.advertising_channel_type import (
+    AdvertisingChannelTypeEnum,
+)
+from google.ads.googleads.v17.enums.types.asset_field_type import (
+    AssetFieldTypeEnum,
+)
+from google.ads.googleads.v17.enums.types.asset_group_status import (
+    AssetGroupStatusEnum,
+)
+from google.ads.googleads.v17.enums.types.asset_type import AssetTypeEnum
+from google.ads.googleads.v17.enums.types.budget_delivery_method import (
+    BudgetDeliveryMethodEnum,
+)
+from google.ads.googleads.v17.enums.types.campaign_status import (
+    CampaignStatusEnum,
+)
+from google.ads.googleads.v17.enums.types.conversion_action_category import (
+    ConversionActionCategoryEnum,
+)
+from google.ads.googleads.v17.enums.types.conversion_origin import (
+    ConversionOriginEnum,
+)
+from google.ads.googleads.v17.enums.types.listing_group_filter_listing_source import (
+    ListingGroupFilterListingSourceEnum,
+)
+from google.ads.googleads.v17.enums.types.listing_group_filter_type import (
+    ListingGroupFilterTypeEnum,
+)
+from google.ads.googleads.v17.resources.types.asset import Asset
+from google.ads.googleads.v17.resources.types.asset_group import AssetGroup
+from google.ads.googleads.v17.resources.types.asset_group_asset import (
+    AssetGroupAsset,
+)
+from google.ads.googleads.v17.resources.types.asset_group_listing_group_filter import (
+    AssetGroupListingGroupFilter,
+)
+from google.ads.googleads.v17.resources.types.campaign import Campaign
+from google.ads.googleads.v17.resources.types.campaign_asset import (
+    CampaignAsset,
+)
+from google.ads.googleads.v17.resources.types.campaign_budget import (
+    CampaignBudget,
+)
+from google.ads.googleads.v17.resources.types.campaign_conversion_goal import (
+    CampaignConversionGoal,
+)
+from google.ads.googleads.v17.resources.types.campaign_criterion import (
+    CampaignCriterion,
+)
+from google.ads.googleads.v17.services.services.asset_group_service import (
+    AssetGroupServiceClient,
+)
+from google.ads.googleads.v17.services.services.asset_service import (
+    AssetServiceClient,
+)
+from google.ads.googleads.v17.services.services.campaign_budget_service import (
+    CampaignBudgetServiceClient,
+)
+from google.ads.googleads.v17.services.services.campaign_conversion_goal_service import (
+    CampaignConversionGoalServiceClient,
+)
+from google.ads.googleads.v17.services.services.campaign_criterion_service import (
+    CampaignCriterionServiceClient,
+)
+from google.ads.googleads.v17.services.services.campaign_service import (
+    CampaignServiceClient,
+)
+from google.ads.googleads.v17.services.services.geo_target_constant_service import (
+    GeoTargetConstantServiceClient,
+)
+from google.ads.googleads.v17.services.services.google_ads_service import (
+    GoogleAdsServiceClient,
+)
+from google.ads.googleads.v17.services.types.google_ads_service import (
+    MutateGoogleAdsResponse,
+    MutateOperationResponse,
+    SearchGoogleAdsRequest,
+    SearchGoogleAdsResponse,
+)
+from google.ads.googleads.v17.services.types.mutate_operation import (
+    MutateOperation,
+)
 
 # We specify temporary IDs that are specific to a single mutate request.
 # Temporary IDs are always negative and unique within one mutate request.
@@ -54,23 +141,23 @@ from google.ads.googleads.util import convert_snake_case_to_upper_case
 # for further details.
 #
 # These temporary IDs are fixed because they are used in multiple places.
-_BUDGET_TEMPORARY_ID = "-1"
-_PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID = "-2"
-_ASSET_GROUP_TEMPORARY_ID = "-3"
+_BUDGET_TEMPORARY_ID: str = "-1"
+_PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID: str = "-2"
+_ASSET_GROUP_TEMPORARY_ID: str = "-3"
 
 # There are also entities that will be created in the same request but do not
 # need to be fixed temporary IDs because they are referenced only once.
-_next_temp_id = int(_ASSET_GROUP_TEMPORARY_ID) - 1
+_next_temp_id: int = int(_ASSET_GROUP_TEMPORARY_ID) - 1
 
 
 # [START add_performance_max_retail_campaign]
 def main(
-    client,
-    customer_id,
-    merchant_center_account_id,
-    final_url,
-    brand_guidelines_enabled,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    merchant_center_account_id: int,
+    final_url: str,
+    brand_guidelines_enabled: bool,
+) -> None:
     """The main method that creates all necessary entities for the example.
 
     Args:
@@ -82,13 +169,15 @@ def main(
           enabled for brand guidelines.
     """
     # [START add_performance_max_retail_campaign_1]
-    googleads_service = client.get_service("GoogleAdsService")
+    googleads_service: GoogleAdsServiceClient = client.get_service(
+        "GoogleAdsService"
+    )
 
     # This campaign will override the customer conversion goals.
     # Retrieve the current list of customer conversion goals.
-    customer_conversion_goals = get_customer_conversion_goals(
-        client, customer_id
-    )
+    customer_conversion_goals: List[
+        Dict[str, Any]
+    ] = get_customer_conversion_goals(client, customer_id)
 
     # Performance Max campaigns require that repeated assets such as headlines
     # and descriptions be created before the campaign.
@@ -96,7 +185,9 @@ def main(
     # https://developers.google.com/google-ads/api/docs/performance-max/assets
     #
     # Create the headlines.
-    headline_asset_resource_names = create_multiple_text_assets(
+    headline_asset_resource_names: List[
+        str
+    ] = create_multiple_text_assets(
         client,
         customer_id,
         [
@@ -106,7 +197,9 @@ def main(
         ],
     )
     # Create the descriptions.
-    description_asset_resource_names = create_multiple_text_assets(
+    description_asset_resource_names: List[
+        str
+    ] = create_multiple_text_assets(
         client,
         customer_id,
         [
@@ -122,11 +215,13 @@ def main(
     # to create them in a single Mutate request so they all complete
     # successfully or fail entirely, leaving no orphaned entities. See:
     # https://developers.google.com/google-ads/api/docs/mutating/overview
-    campaign_budget_operation = create_campaign_budget_operation(
-        client,
-        customer_id,
+    campaign_budget_operation: MutateOperation = (
+        create_campaign_budget_operation(
+            client,
+            customer_id,
+        )
     )
-    performance_max_campaign_operation = (
+    performance_max_campaign_operation: MutateOperation = (
         create_performance_max_campaign_operation(
             client,
             customer_id,
@@ -134,17 +229,19 @@ def main(
             brand_guidelines_enabled,
         )
     )
-    campaign_criterion_operations = create_campaign_criterion_operations(
+    campaign_criterion_operations: List[
+        MutateOperation
+    ] = create_campaign_criterion_operations(
         client,
         customer_id,
     )
-    asset_group_operation = create_asset_group_operation(
+    asset_group_operation: MutateOperation = create_asset_group_operation(
         client, customer_id, final_url
     )
-    listing_group_filter_operation = create_listing_group_filter_operation(
-        client, customer_id
+    listing_group_filter_operation: MutateOperation = (
+        create_listing_group_filter_operation(client, customer_id)
     )
-    asset_and_asset_group_asset_operations = (
+    asset_and_asset_group_asset_operations: List[MutateOperation] = (
         create_asset_and_asset_group_asset_operations(
             client,
             customer_id,
@@ -153,14 +250,16 @@ def main(
             brand_guidelines_enabled,
         )
     )
-    conversion_goal_operations = create_conversion_goal_operations(
+    conversion_goal_operations: List[
+        MutateOperation
+    ] = create_conversion_goal_operations(
         client,
         customer_id,
         customer_conversion_goals,
     )
 
     # Send the operations in a single Mutate request.
-    response = googleads_service.mutate(
+    response: MutateGoogleAdsResponse = googleads_service.mutate(
         customer_id=customer_id,
         mutate_operations=[
             # It's important to create these entities in this order because
@@ -182,9 +281,9 @@ def main(
 
 # [START add_performance_max_retail_campaign_2]
 def create_campaign_budget_operation(
-    client,
-    customer_id,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new CampaignBudget.
 
     A temporary ID will be assigned to this campaign budget so that it can be
@@ -197,9 +296,9 @@ def create_campaign_budget_operation(
     Returns:
         a MutateOperation that creates a CampaignBudget.
     """
-    mutate_operation = client.get_type("MutateOperation")
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
     campaign_budget_operation = mutate_operation.campaign_budget_operation
-    campaign_budget = campaign_budget_operation.create
+    campaign_budget: CampaignBudget = campaign_budget_operation.create
     campaign_budget.name = f"Performance Max retail campaign budget #{uuid4()}"
     # The budget period already defaults to DAILY.
     campaign_budget.amount_micros = 50000000
@@ -211,9 +310,12 @@ def create_campaign_budget_operation(
 
     # Set a temporary ID in the budget's resource name so it can be referenced
     # by the campaign in later steps.
-    campaign_budget.resource_name = client.get_service(
+    campaign_budget_service: CampaignBudgetServiceClient = client.get_service(
         "CampaignBudgetService"
-    ).campaign_budget_path(customer_id, _BUDGET_TEMPORARY_ID)
+    )
+    campaign_budget.resource_name = campaign_budget_service.campaign_budget_path(
+        customer_id, _BUDGET_TEMPORARY_ID
+    )
 
     return mutate_operation
     # [END add_performance_max_retail_campaign_2]
@@ -221,11 +323,11 @@ def create_campaign_budget_operation(
 
 # [START add_performance_max_retail_campaign_3]
 def create_performance_max_campaign_operation(
-    client,
-    customer_id,
-    merchant_center_account_id,
-    brand_guidelines_enabled,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    merchant_center_account_id: int,
+    brand_guidelines_enabled: bool,
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new Performance Max campaign.
 
     A temporary ID will be assigned to this campaign so that it can
@@ -241,8 +343,8 @@ def create_performance_max_campaign_operation(
     Returns:
         a MutateOperation that creates a campaign.
     """
-    mutate_operation = client.get_type("MutateOperation")
-    campaign = mutate_operation.campaign_operation.create
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
+    campaign: Campaign = mutate_operation.campaign_operation.create
     campaign.name = f"Performance Max retail campaign #{uuid4()}"
     # Set the campaign status as PAUSED. The campaign is the only entity in
     # the mutate request that should have its status set.
@@ -297,12 +399,17 @@ def create_performance_max_campaign_operation(
     campaign.brand_guidelines_enabled = brand_guidelines_enabled
 
     # Assign the resource name with a temporary ID.
-    campaign_service = client.get_service("CampaignService")
+    campaign_service: CampaignServiceClient = client.get_service(
+        "CampaignService"
+    )
     campaign.resource_name = campaign_service.campaign_path(
         customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
     )
     # Set the budget using the given budget resource name.
-    campaign.campaign_budget = campaign_service.campaign_budget_path(
+    campaign_budget_service: CampaignBudgetServiceClient = client.get_service(
+        "CampaignBudgetService"
+    )
+    campaign.campaign_budget = campaign_budget_service.campaign_budget_path(
         customer_id, _BUDGET_TEMPORARY_ID
     )
 
@@ -316,9 +423,9 @@ def create_performance_max_campaign_operation(
 
 # [START add_performance_max_retail_campaign_4]
 def create_campaign_criterion_operations(
-    client,
-    customer_id,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that create new campaign criteria.
 
     Args:
@@ -328,62 +435,78 @@ def create_campaign_criterion_operations(
     Returns:
         a list of MutateOperations that create new campaign criteria.
     """
-    campaign_service = client.get_service("CampaignService")
-    geo_target_constant_service = client.get_service("GeoTargetConstantService")
-    googleads_service = client.get_service("GoogleAdsService")
+    campaign_service: CampaignServiceClient = client.get_service(
+        "CampaignService"
+    )
+    geo_target_constant_service: GeoTargetConstantServiceClient = (
+        client.get_service("GeoTargetConstantService")
+    )
+    googleads_service: GoogleAdsServiceClient = client.get_service(
+        "GoogleAdsService"
+    )
 
-    operations = []
+    operations: List[MutateOperation] = []
     # Set the LOCATION campaign criteria.
     # Target all of New York City except Brooklyn.
     # Location IDs are listed here:
     # https://developers.google.com/google-ads/api/reference/data/geotargets
     # and they can also be retrieved using the GeoTargetConstantService as shown
     # here: https://developers.google.com/google-ads/api/docs/targeting/location-targeting
-    mutate_operation = client.get_type("MutateOperation")
-    campaign_criterion = mutate_operation.campaign_criterion_operation.create
-    campaign_criterion.campaign = campaign_service.campaign_path(
+    mutate_operation_nyc: MutateOperation = client.get_type("MutateOperation")
+    campaign_criterion_nyc: CampaignCriterion = (
+        mutate_operation_nyc.campaign_criterion_operation.create
+    )
+    campaign_criterion_nyc.campaign = campaign_service.campaign_path(
         customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
     )
     # Adds one positive location target for New York City (ID=1023191),
     # specifically adding the positive criteria before the negative one.
-    campaign_criterion.location.geo_target_constant = (
+    campaign_criterion_nyc.location.geo_target_constant = (
         geo_target_constant_service.geo_target_constant_path("1023191")
     )
-    campaign_criterion.negative = False
-    operations.append(mutate_operation)
+    campaign_criterion_nyc.negative = False
+    operations.append(mutate_operation_nyc)
 
     # Next add the negative target for Brooklyn (ID=1022762).
-    mutate_operation = client.get_type("MutateOperation")
-    campaign_criterion = mutate_operation.campaign_criterion_operation.create
-    campaign_criterion.campaign = campaign_service.campaign_path(
+    mutate_operation_brooklyn: MutateOperation = client.get_type(
+        "MutateOperation"
+    )
+    campaign_criterion_brooklyn: CampaignCriterion = (
+        mutate_operation_brooklyn.campaign_criterion_operation.create
+    )
+    campaign_criterion_brooklyn.campaign = campaign_service.campaign_path(
         customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
     )
-    campaign_criterion.location.geo_target_constant = (
+    campaign_criterion_brooklyn.location.geo_target_constant = (
         geo_target_constant_service.geo_target_constant_path("1022762")
     )
-    campaign_criterion.negative = True
-    operations.append(mutate_operation)
+    campaign_criterion_brooklyn.negative = True
+    operations.append(mutate_operation_brooklyn)
 
     # Set the LANGUAGE campaign criterion.
-    mutate_operation = client.get_type("MutateOperation")
-    campaign_criterion = mutate_operation.campaign_criterion_operation.create
-    campaign_criterion.campaign = campaign_service.campaign_path(
+    mutate_operation_lang: MutateOperation = client.get_type("MutateOperation")
+    campaign_criterion_lang: CampaignCriterion = (
+        mutate_operation_lang.campaign_criterion_operation.create
+    )
+    campaign_criterion_lang.campaign = campaign_service.campaign_path(
         customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
     )
     # Set the language.
     # For a list of all language codes, see:
     # https://developers.google.com/google-ads/api/reference/data/codes-formats#expandable-7
-    campaign_criterion.language.language_constant = (
+    campaign_criterion_lang.language.language_constant = (
         googleads_service.language_constant_path("1000")
     )  # English
-    operations.append(mutate_operation)
+    operations.append(mutate_operation_lang)
 
     return operations
     # [END add_performance_max_retail_campaign_4]
 
 
 # [START add_performance_max_retail_campaign_5]
-def create_multiple_text_assets(client, customer_id, texts):
+def create_multiple_text_assets(
+    client: GoogleAdsClient, customer_id: str, texts: List[str]
+) -> List[str]:
     """Creates multiple text assets and returns the list of resource names.
 
     These repeated assets must be created in a separate request prior to
@@ -400,21 +523,23 @@ def create_multiple_text_assets(client, customer_id, texts):
     """
     # Here again we use the GoogleAdService to create multiple text
     # assets in a single request.
-    googleads_service = client.get_service("GoogleAdsService")
+    googleads_service: GoogleAdsServiceClient = client.get_service(
+        "GoogleAdsService"
+    )
 
-    operations = []
-    for text in texts:
-        mutate_operation = client.get_type("MutateOperation")
-        asset = mutate_operation.asset_operation.create
-        asset.text_asset.text = text
+    operations: List[MutateOperation] = []
+    for text_content in texts:
+        mutate_operation: MutateOperation = client.get_type("MutateOperation")
+        asset: Asset = mutate_operation.asset_operation.create
+        asset.text_asset.text = text_content
         operations.append(mutate_operation)
 
     # Send the operations in a single Mutate request.
-    response = googleads_service.mutate(
+    response: MutateGoogleAdsResponse = googleads_service.mutate(
         customer_id=customer_id,
         mutate_operations=operations,
     )
-    asset_resource_names = []
+    asset_resource_names: List[str] = []
     for result in response.mutate_operation_responses:
         if result._pb.HasField("asset_result"):
             asset_resource_names.append(result.asset_result.resource_name)
@@ -424,7 +549,9 @@ def create_multiple_text_assets(client, customer_id, texts):
 
 
 # [START add_performance_max_retail_campaign_10]
-def create_asset_group_operation(client, customer_id, final_url):
+def create_asset_group_operation(
+    client: GoogleAdsClient, customer_id: str, final_url: str
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new asset group.
 
     A temporary ID will be assigned to this asset group so that it can
@@ -438,18 +565,26 @@ def create_asset_group_operation(client, customer_id, final_url):
     Returns:
         a MutateOperation that creates a new asset group.
     """
-    googleads_service = client.get_service("GoogleAdsService")
+    googleads_service: GoogleAdsServiceClient = client.get_service(
+        "GoogleAdsService"
+    )
+    campaign_service: CampaignServiceClient = client.get_service(
+        "CampaignService"
+    )
+    asset_group_service: AssetGroupServiceClient = client.get_service(
+        "AssetGroupService"
+    )
     # Create the AssetGroup.
-    mutate_operation = client.get_type("MutateOperation")
-    asset_group = mutate_operation.asset_group_operation.create
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
+    asset_group: AssetGroup = mutate_operation.asset_group_operation.create
     asset_group.name = f"Performance Max retail asset group #{uuid4()}"
-    asset_group.campaign = googleads_service.campaign_path(
+    asset_group.campaign = campaign_service.campaign_path(
         customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
     )
     asset_group.final_urls.append(final_url)
     asset_group.final_mobile_urls.append(final_url)
     asset_group.status = client.enums.AssetGroupStatusEnum.PAUSED
-    asset_group.resource_name = googleads_service.asset_group_path(
+    asset_group.resource_name = asset_group_service.asset_group_path(
         customer_id,
         _ASSET_GROUP_TEMPORARY_ID,
     )
@@ -459,7 +594,9 @@ def create_asset_group_operation(client, customer_id, final_url):
 
 
 # [START add_performance_max_retail_campaign_11]
-def create_listing_group_filter_operation(client, customer_id):
+def create_listing_group_filter_operation(
+    client: GoogleAdsClient, customer_id: str
+) -> MutateOperation:
     """Creates a MutateOperation that creates a new listing group filter.
 
     A temporary ID will be assigned to this listing group filter so that it
@@ -472,16 +609,20 @@ def create_listing_group_filter_operation(client, customer_id):
     Returns:
         a MutateOperation that creates a new listing group filter.
     """
-    googleads_service = client.get_service("GoogleAdsService")
+    asset_group_service: AssetGroupServiceClient = client.get_service(
+        "AssetGroupService"
+    )
     # Creates a new ad group criterion containing the "default" listing
     # group (All products).
-    mutate_operation = client.get_type("MutateOperation")
-    asset_group_listing_group = (
+    mutate_operation: MutateOperation = client.get_type("MutateOperation")
+    asset_group_listing_group: AssetGroupListingGroupFilter = (
         mutate_operation.asset_group_listing_group_filter_operation.create
     )
-    asset_group_listing_group.asset_group = googleads_service.asset_group_path(
-        customer_id,
-        _ASSET_GROUP_TEMPORARY_ID,
+    asset_group_listing_group.asset_group = (
+        asset_group_service.asset_group_path(
+            customer_id,
+            _ASSET_GROUP_TEMPORARY_ID,
+        )
     )
     asset_group_listing_group.type_ = (
         client.enums.ListingGroupFilterTypeEnum.UNIT_INCLUDED
@@ -498,12 +639,12 @@ def create_listing_group_filter_operation(client, customer_id):
 
 # [START add_performance_max_retail_campaign_6]
 def create_asset_and_asset_group_asset_operations(
-    client,
-    customer_id,
-    headline_asset_resource_names,
-    description_asset_resource_names,
-    brand_guidelines_enabled,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    headline_asset_resource_names: List[str],
+    description_asset_resource_names: List[str],
+    brand_guidelines_enabled: bool,
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that create a new asset_group.
 
     A temporary ID will be assigned to this asset group so that it can
@@ -520,9 +661,11 @@ def create_asset_and_asset_group_asset_operations(
     Returns:
         MutateOperations that create a new asset group and related assets.
     """
-    asset_group_service = client.get_service("AssetGroupService")
+    asset_group_service: AssetGroupServiceClient = client.get_service(
+        "AssetGroupService"
+    )
 
-    operations = []
+    operations: List[MutateOperation] = []
 
     # For the list of required assets for a Performance Max campaign, see
     # https://developers.google.com/google-ads/api/docs/performance-max/assets
@@ -540,8 +683,10 @@ def create_asset_and_asset_group_asset_operations(
 
     # Link the headline assets.
     for resource_name in headline_asset_resource_names:
-        mutate_operation = client.get_type("MutateOperation")
-        asset_group_asset = mutate_operation.asset_group_asset_operation.create
+        mutate_operation: MutateOperation = client.get_type("MutateOperation")
+        asset_group_asset: AssetGroupAsset = (
+            mutate_operation.asset_group_asset_operation.create
+        )
         asset_group_asset.field_type = client.enums.AssetFieldTypeEnum.HEADLINE
         asset_group_asset.asset_group = asset_group_service.asset_group_path(
             customer_id,
@@ -552,8 +697,10 @@ def create_asset_and_asset_group_asset_operations(
 
     #  Link the description assets.
     for resource_name in description_asset_resource_names:
-        mutate_operation = client.get_type("MutateOperation")
-        asset_group_asset = mutate_operation.asset_group_asset_operation.create
+        mutate_operation: MutateOperation = client.get_type("MutateOperation")
+        asset_group_asset: AssetGroupAsset = (
+            mutate_operation.asset_group_asset_operation.create
+        )
         asset_group_asset.field_type = (
             client.enums.AssetFieldTypeEnum.DESCRIPTION
         )
@@ -565,46 +712,54 @@ def create_asset_and_asset_group_asset_operations(
         operations.append(mutate_operation)
 
     # Create and link the long headline text asset.
-    mutate_operations = create_and_link_text_asset(
-        client,
-        customer_id,
-        "Travel the World",
-        client.enums.AssetFieldTypeEnum.LONG_HEADLINE,
+    mutate_operations_long_headline: List[MutateOperation] = (
+        create_and_link_text_asset(
+            client,
+            customer_id,
+            "Travel the World",
+            client.enums.AssetFieldTypeEnum.LONG_HEADLINE,
+        )
     )
-    operations.extend(mutate_operations)
+    operations.extend(mutate_operations_long_headline)
 
     # Create and link the business name and logo asset.
-    mutate_operations = create_and_link_brand_assets(
-        client,
-        customer_id,
-        brand_guidelines_enabled,
-        "Interplanetary Cruises",
-        "https://gaagl.page.link/1Crm",
-        "Logo Image",
+    mutate_operations_brand: List[MutateOperation] = (
+        create_and_link_brand_assets(
+            client,
+            customer_id,
+            brand_guidelines_enabled,
+            "Interplanetary Cruises",
+            "https://gaagl.page.link/1Crm",
+            "Logo Image",
+        )
     )
-    operations.extend(mutate_operations)
+    operations.extend(mutate_operations_brand)
 
     # Create and link the image assets.
 
     # Create and link the Marketing Image Asset.
-    mutate_operations = create_and_link_image_asset(
-        client,
-        customer_id,
-        "https://gaagl.page.link/Eit5",
-        client.enums.AssetFieldTypeEnum.MARKETING_IMAGE,
-        "Marketing Image",
+    mutate_operations_marketing_image: List[MutateOperation] = (
+        create_and_link_image_asset(
+            client,
+            customer_id,
+            "https://gaagl.page.link/Eit5",
+            client.enums.AssetFieldTypeEnum.MARKETING_IMAGE,
+            "Marketing Image",
+        )
     )
-    operations.extend(mutate_operations)
+    operations.extend(mutate_operations_marketing_image)
 
     # Create and link the Square Marketing Image Asset.
-    mutate_operations = create_and_link_image_asset(
-        client,
-        customer_id,
-        "https://gaagl.page.link/bjYi",
-        client.enums.AssetFieldTypeEnum.SQUARE_MARKETING_IMAGE,
-        "Square Marketing Image",
+    mutate_operations_square_image: List[MutateOperation] = (
+        create_and_link_image_asset(
+            client,
+            customer_id,
+            "https://gaagl.page.link/bjYi",
+            client.enums.AssetFieldTypeEnum.SQUARE_MARKETING_IMAGE,
+            "Square Marketing Image",
+        )
     )
-    operations.extend(mutate_operations)
+    operations.extend(mutate_operations_square_image)
 
     # After being created the list must be sorted so that all asset
     # operations come before all the asset group asset operations,
@@ -614,7 +769,12 @@ def create_asset_and_asset_group_asset_operations(
 
 
 # [START add_performance_max_retail_campaign_7]
-def create_and_link_text_asset(client, customer_id, text, field_type):
+def create_and_link_text_asset(
+    client: GoogleAdsClient,
+    customer_id: str,
+    text: str,
+    field_type: AssetFieldTypeEnum.AssetFieldType,
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that create a new linked text asset.
 
     Args:
@@ -627,29 +787,36 @@ def create_and_link_text_asset(client, customer_id, text, field_type):
         MutateOperations that create a new linked text asset.
     """
     global _next_temp_id
-    operations = []
-    asset_service = client.get_service("AssetService")
-    asset_group_service = client.get_service("AssetGroupService")
+    operations: List[MutateOperation] = []
+    asset_service: AssetServiceClient = client.get_service("AssetService")
+    asset_group_service: AssetGroupServiceClient = client.get_service(
+        "AssetGroupService"
+    )
 
     # Create the Text Asset.
-    mutate_operation = client.get_type("MutateOperation")
-    asset = mutate_operation.asset_operation.create
-    asset.resource_name = asset_service.asset_path(customer_id, _next_temp_id)
+    asset_temp_resource_name = asset_service.asset_path(
+        customer_id, str(_next_temp_id)
+    )
+    mutate_operation_asset: MutateOperation = client.get_type("MutateOperation")
+    asset: Asset = mutate_operation_asset.asset_operation.create
+    asset.resource_name = asset_temp_resource_name
     asset.text_asset.text = text
-    operations.append(mutate_operation)
+    operations.append(mutate_operation_asset)
 
     # Create an AssetGroupAsset to link the Asset to the AssetGroup.
-    mutate_operation = client.get_type("MutateOperation")
-    asset_group_asset = mutate_operation.asset_group_asset_operation.create
+    mutate_operation_group_asset: MutateOperation = client.get_type(
+        "MutateOperation"
+    )
+    asset_group_asset: AssetGroupAsset = (
+        mutate_operation_group_asset.asset_group_asset_operation.create
+    )
     asset_group_asset.field_type = field_type
     asset_group_asset.asset_group = asset_group_service.asset_group_path(
         customer_id,
         _ASSET_GROUP_TEMPORARY_ID,
     )
-    asset_group_asset.asset = asset_service.asset_path(
-        customer_id, _next_temp_id
-    )
-    operations.append(mutate_operation)
+    asset_group_asset.asset = asset_temp_resource_name
+    operations.append(mutate_operation_group_asset)
 
     _next_temp_id -= 1
     return operations
@@ -658,8 +825,12 @@ def create_and_link_text_asset(client, customer_id, text, field_type):
 
 # [START add_performance_max_retail_campaign_8]
 def create_and_link_image_asset(
-    client, customer_id, url, field_type, asset_name
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    url: str,
+    field_type: AssetFieldTypeEnum.AssetFieldType,
+    asset_name: str,
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that create a new linked image asset.
 
     Args:
@@ -673,34 +844,41 @@ def create_and_link_image_asset(
         MutateOperations that create a new linked image asset.
     """
     global _next_temp_id
-    operations = []
-    asset_service = client.get_service("AssetService")
-    asset_group_service = client.get_service("AssetGroupService")
+    operations: List[MutateOperation] = []
+    asset_service: AssetServiceClient = client.get_service("AssetService")
+    asset_group_service: AssetGroupServiceClient = client.get_service(
+        "AssetGroupService"
+    )
 
     # Create the Image Asset.
-    mutate_operation = client.get_type("MutateOperation")
-    asset = mutate_operation.asset_operation.create
-    asset.resource_name = asset_service.asset_path(customer_id, _next_temp_id)
+    asset_temp_resource_name = asset_service.asset_path(
+        customer_id, str(_next_temp_id)
+    )
+    mutate_operation_asset: MutateOperation = client.get_type("MutateOperation")
+    asset: Asset = mutate_operation_asset.asset_operation.create
+    asset.resource_name = asset_temp_resource_name
     asset.type_ = client.enums.AssetTypeEnum.IMAGE
     # Provide a unique friendly name to identify your asset.
     # When there is an existing image asset with the same content but a different
     # name, the new name will be dropped silently.
     asset.name = asset_name
     asset.image_asset.data = get_image_bytes_from_url(url)
-    operations.append(mutate_operation)
+    operations.append(mutate_operation_asset)
 
     # Create an AssetGroupAsset to link the Asset to the AssetGroup.
-    mutate_operation = client.get_type("MutateOperation")
-    asset_group_asset = mutate_operation.asset_group_asset_operation.create
+    mutate_operation_group_asset: MutateOperation = client.get_type(
+        "MutateOperation"
+    )
+    asset_group_asset: AssetGroupAsset = (
+        mutate_operation_group_asset.asset_group_asset_operation.create
+    )
     asset_group_asset.field_type = field_type
     asset_group_asset.asset_group = asset_group_service.asset_group_path(
         customer_id,
         _ASSET_GROUP_TEMPORARY_ID,
     )
-    asset_group_asset.asset = asset_service.asset_path(
-        customer_id, _next_temp_id
-    )
-    operations.append(mutate_operation)
+    asset_group_asset.asset = asset_temp_resource_name
+    operations.append(mutate_operation_group_asset)
 
     _next_temp_id -= 1
     return operations
@@ -708,7 +886,9 @@ def create_and_link_image_asset(
 
 
 # [START add_performance_max_retail_campaign_12]
-def sort_asset_and_asset_group_asset_operations(operations):
+def sort_asset_and_asset_group_asset_operations(
+    operations: List[MutateOperation],
+) -> List[MutateOperation]:
     """Sorts a list of asset and asset group asset operations.
 
     This sorts the list such that all asset operations precede
@@ -723,7 +903,7 @@ def sort_asset_and_asset_group_asset_operations(operations):
         a sorted list of asset and asset group asset operations.
     """
 
-    def sorter(operation):
+    def sorter(operation: MutateOperation) -> bool:
         """Determines whether the operation creates an asset group asset.
 
         Args:
@@ -732,14 +912,19 @@ def sort_asset_and_asset_group_asset_operations(operations):
         Returns:
             True if the MutateOperation creates an asset group asset.
         """
-        return bool(operation.asset_group_asset_operation)
+        # Check if the oneof field 'asset_group_asset_operation' is set.
+        return operation.asset_group_asset_operation != type(
+            operation.asset_group_asset_operation
+        )()
 
     return sorted(operations, key=sorter)
     # [END add_performance_max_retail_campaign_12]
 
 
 # [START add_performance_max_retail_campaign_9]
-def get_customer_conversion_goals(client, customer_id):
+def get_customer_conversion_goals(
+    client: GoogleAdsClient, customer_id: str
+) -> List[Dict[str, Any]]:
     """Retrieves the list of customer conversion goals.
 
     Args:
@@ -750,9 +935,9 @@ def get_customer_conversion_goals(client, customer_id):
         a list of dicts containing the category and origin of customer
         conversion goals.
     """
-    ga_service = client.get_service("GoogleAdsService")
-    customer_conversion_goals = []
-    query = """
+    ga_service: GoogleAdsServiceClient = client.get_service("GoogleAdsService")
+    customer_conversion_goals: List[Dict[str, Any]] = []
+    query: str = """
             SELECT
               customer_conversion_goal.category,
               customer_conversion_goal.origin
@@ -760,10 +945,12 @@ def get_customer_conversion_goals(client, customer_id):
             """
     # The number of conversion goals is typically less than 50 so we use
     # GoogleAdsService.search instead of search_stream.
-    search_request = client.get_type("SearchGoogleAdsRequest")
+    search_request: SearchGoogleAdsRequest = client.get_type(
+        "SearchGoogleAdsRequest"
+    )
     search_request.customer_id = customer_id
     search_request.query = query
-    results = ga_service.search(request=search_request)
+    results: SearchGoogleAdsResponse = ga_service.search(request=search_request)
 
     # Iterate over the results and build the list of conversion goals.
     for row in results:
@@ -777,10 +964,10 @@ def get_customer_conversion_goals(client, customer_id):
 
 
 def create_conversion_goal_operations(
-    client,
-    customer_id,
-    customer_conversion_goals,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    customer_conversion_goals: List[Dict[str, Any]],
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that override customer conversion goals.
 
     Args:
@@ -792,26 +979,33 @@ def create_conversion_goal_operations(
     Returns:
         MutateOperations that update campaign conversion goals.
     """
-    campaign_conversion_goal_service = client.get_service(
-        "CampaignConversionGoalService"
+    campaign_conversion_goal_service: CampaignConversionGoalServiceClient = (
+        client.get_service("CampaignConversionGoalService")
     )
-    operations = []
+    operations: List[MutateOperation] = []
 
     # To override the customer conversion goals, we will change the
     # biddability of each of the customer conversion goals so that only
     # the desired conversion goal is biddable in this campaign.
-    for customer_conversion_goal in customer_conversion_goals:
-        mutate_operation = client.get_type("MutateOperation")
-        campaign_conversion_goal = (
+    for customer_goal_dict in customer_conversion_goals:
+        mutate_operation: MutateOperation = client.get_type("MutateOperation")
+        campaign_conversion_goal: CampaignConversionGoal = (
             mutate_operation.campaign_conversion_goal_operation.update
         )
+
+        category_enum_value: ConversionActionCategoryEnum.ConversionActionCategory = customer_goal_dict[
+            "category"
+        ]
+        origin_enum_value: ConversionOriginEnum.ConversionOrigin = customer_goal_dict[
+            "origin"
+        ]
 
         campaign_conversion_goal.resource_name = (
             campaign_conversion_goal_service.campaign_conversion_goal_path(
                 customer_id,
                 _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID,
-                customer_conversion_goal["category"].name,
-                customer_conversion_goal["origin"].name,
+                category_enum_value.name,
+                origin_enum_value.name,
             )
         )
         # Change the biddability for the campaign conversion goal.
@@ -823,9 +1017,9 @@ def create_conversion_goal_operations(
         #  2- More than one goal can be biddable if desired. This example
         #     shows only one.
         if (
-            customer_conversion_goal["category"]
+            category_enum_value
             == client.enums.ConversionActionCategoryEnum.PURCHASE
-            and customer_conversion_goal["origin"]
+            and origin_enum_value
             == client.enums.ConversionOriginEnum.WEBSITE
         ):
             biddable = True
@@ -846,13 +1040,13 @@ def create_conversion_goal_operations(
 
 
 def create_and_link_brand_assets(
-    client,
-    customer_id,
-    brand_guidelines_enabled,
-    business_name,
-    logo_url,
-    logo_name,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    brand_guidelines_enabled: bool,
+    business_name: str,
+    logo_url: str,
+    logo_name: str,
+) -> List[MutateOperation]:
     """Creates a list of MutateOperations that create linked brand assets.
 
     Args:
@@ -868,45 +1062,51 @@ def create_and_link_brand_assets(
         MutateOperations that create linked brand assets.
     """
     global _next_temp_id
-    operations = []
-    asset_service = client.get_service("AssetService")
+    operations: List[MutateOperation] = []
+    asset_service: AssetServiceClient = client.get_service("AssetService")
 
     # Create the Text Asset.
-    text_asset_temp_id = _next_temp_id
+    text_asset_temp_id: int = _next_temp_id
     _next_temp_id -= 1
-
-    text_mutate_operation = client.get_type("MutateOperation")
-    text_asset = text_mutate_operation.asset_operation.create
-    text_asset.resource_name = asset_service.asset_path(
-        customer_id, text_asset_temp_id
+    text_asset_resource_name = asset_service.asset_path(
+        customer_id, str(text_asset_temp_id)
     )
-    text_asset.text_asset.text = business_name
+
+    text_mutate_operation: MutateOperation = client.get_type("MutateOperation")
+    text_asset_obj: Asset = text_mutate_operation.asset_operation.create
+    text_asset_obj.resource_name = text_asset_resource_name
+    text_asset_obj.text_asset.text = business_name
     operations.append(text_mutate_operation)
 
     # Create the Image Asset.
-    image_asset_temp_id = _next_temp_id
+    image_asset_temp_id: int = _next_temp_id
     _next_temp_id -= 1
-
-    image_mutate_operation = client.get_type("MutateOperation")
-    image_asset = image_mutate_operation.asset_operation.create
-    image_asset.resource_name = asset_service.asset_path(
-        customer_id, image_asset_temp_id
+    image_asset_resource_name = asset_service.asset_path(
+        customer_id, str(image_asset_temp_id)
     )
+
+    image_mutate_operation: MutateOperation = client.get_type("MutateOperation")
+    image_asset_obj: Asset = image_mutate_operation.asset_operation.create
+    image_asset_obj.resource_name = image_asset_resource_name
     # Provide a unique friendly name to identify your asset.
     # When there is an existing image asset with the same content but a different
     # name, the new name will be dropped silently.
-    image_asset.name = logo_name
-    image_asset.type_ = client.enums.AssetTypeEnum.IMAGE
-    image_asset.image_asset.data = get_image_bytes_from_url(logo_url)
+    image_asset_obj.name = logo_name
+    image_asset_obj.type_ = client.enums.AssetTypeEnum.IMAGE
+    image_asset_obj.image_asset.data = get_image_bytes_from_url(logo_url)
     operations.append(image_mutate_operation)
 
     if brand_guidelines_enabled:
         # Create CampaignAsset resources to link the Asset resources to the Campaign.
-        campaign_service = client.get_service("CampaignService")
+        campaign_service: CampaignServiceClient = client.get_service(
+            "CampaignService"
+        )
 
-        business_name_mutate_operation = client.get_type("MutateOperation")
-        business_name_campaign_asset = (
-            business_name_mutate_operation.campaign_asset_operation.create
+        business_name_ca_mutate_op: MutateOperation = client.get_type(
+            "MutateOperation"
+        )
+        business_name_campaign_asset: CampaignAsset = (
+            business_name_ca_mutate_op.campaign_asset_operation.create
         )
         business_name_campaign_asset.field_type = (
             client.enums.AssetFieldTypeEnum.BUSINESS_NAME
@@ -914,31 +1114,31 @@ def create_and_link_brand_assets(
         business_name_campaign_asset.campaign = campaign_service.campaign_path(
             customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
         )
-        business_name_campaign_asset.asset = asset_service.asset_path(
-            customer_id, text_asset_temp_id
-        )
-        operations.append(business_name_mutate_operation)
+        business_name_campaign_asset.asset = text_asset_resource_name
+        operations.append(business_name_ca_mutate_op)
 
-        logo_mutate_operation = client.get_type("MutateOperation")
-        logo_campaign_asset = (
-            logo_mutate_operation.campaign_asset_operation.create
+        logo_ca_mutate_op: MutateOperation = client.get_type("MutateOperation")
+        logo_campaign_asset: CampaignAsset = (
+            logo_ca_mutate_op.campaign_asset_operation.create
         )
         logo_campaign_asset.field_type = client.enums.AssetFieldTypeEnum.LOGO
         logo_campaign_asset.campaign = campaign_service.campaign_path(
             customer_id, _PERFORMANCE_MAX_CAMPAIGN_TEMPORARY_ID
         )
-        logo_campaign_asset.asset = asset_service.asset_path(
-            customer_id, image_asset_temp_id
-        )
-        operations.append(logo_mutate_operation)
+        logo_campaign_asset.asset = image_asset_resource_name
+        operations.append(logo_ca_mutate_op)
 
     else:
         # Create AssetGroupAsset resources to link the Asset resources to the AssetGroup.
-        asset_group_service = client.get_service("AssetGroupService")
+        asset_group_service: AssetGroupServiceClient = client.get_service(
+            "AssetGroupService"
+        )
 
-        business_name_mutate_operation = client.get_type("MutateOperation")
-        business_name_asset_group_asset = (
-            business_name_mutate_operation.asset_group_asset_operation.create
+        business_name_aga_mutate_op: MutateOperation = client.get_type(
+            "MutateOperation"
+        )
+        business_name_asset_group_asset: AssetGroupAsset = (
+            business_name_aga_mutate_op.asset_group_asset_operation.create
         )
         business_name_asset_group_asset.field_type = (
             client.enums.AssetFieldTypeEnum.BUSINESS_NAME
@@ -949,14 +1149,12 @@ def create_and_link_brand_assets(
                 _ASSET_GROUP_TEMPORARY_ID,
             )
         )
-        business_name_asset_group_asset.asset = asset_service.asset_path(
-            customer_id, text_asset_temp_id
-        )
-        operations.append(business_name_mutate_operation)
+        business_name_asset_group_asset.asset = text_asset_resource_name
+        operations.append(business_name_aga_mutate_op)
 
-        logo_mutate_operation = client.get_type("MutateOperation")
-        logo_asset_group_asset = (
-            logo_mutate_operation.asset_group_asset_operation.create
+        logo_aga_mutate_op: MutateOperation = client.get_type("MutateOperation")
+        logo_asset_group_asset: AssetGroupAsset = (
+            logo_aga_mutate_op.asset_group_asset_operation.create
         )
         logo_asset_group_asset.field_type = client.enums.AssetFieldTypeEnum.LOGO
         logo_asset_group_asset.asset_group = (
@@ -965,15 +1163,13 @@ def create_and_link_brand_assets(
                 _ASSET_GROUP_TEMPORARY_ID,
             )
         )
-        logo_asset_group_asset.asset = asset_service.asset_path(
-            customer_id, image_asset_temp_id
-        )
-        operations.append(logo_mutate_operation)
+        logo_asset_group_asset.asset = image_asset_resource_name
+        operations.append(logo_aga_mutate_op)
 
     return operations
 
 
-def print_response_details(response):
+def print_response_details(response: MutateGoogleAdsResponse) -> None:
     """Prints the details of a MutateGoogleAdsResponse.
 
     Parses the "response" oneof field name and uses it to extract the new
@@ -984,13 +1180,16 @@ def print_response_details(response):
     """
     # Parse the Mutate response to print details about the entities that
     # were created by the request.
-    suffix = "_result"
-    for result in response.mutate_operation_responses:
-        for field_descriptor, value in result._pb.ListFields():
-            if field_descriptor.name.endswith(suffix):
-                name = field_descriptor.name[: -len(suffix)]
+    suffix: str = "_result"
+    for result_item in response.mutate_operation_responses:
+        # Ensure result_item is MutateOperationResponse, not just Any
+        result_pb: MutateOperationResponse = result_item
+        for field_descriptor, value in result_pb._pb.ListFields():
+            field_name_str: str = field_descriptor.name
+            if field_name_str.endswith(suffix):
+                name = field_name_str[: -len(suffix)]
             else:
-                name = field_descriptor.name
+                name = field_name_str
             print(
                 f"Created a(n) {convert_snake_case_to_upper_case(name)} with "
                 f"{str(value).strip()}."
@@ -1037,11 +1236,13 @@ if __name__ == "__main__":
         ),
     )
 
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(
@@ -1057,7 +1258,7 @@ if __name__ == "__main__":
             f'"{ex.error.code().name}" and includes the following errors:'
         )
         for error in ex.failure.errors:
-            print(f'Error with message "{error.message}".')
+            print(f'\tError with message "{error.message}".')
             if error.location:
                 for field_path_element in error.location.field_path_elements:
                     print(f"\t\tOn field: {field_path_element.field_name}")

--- a/examples/shopping_ads/add_shopping_product_listing_group_tree.py
+++ b/examples/shopping_ads/add_shopping_product_listing_group_tree.py
@@ -27,14 +27,49 @@ ProductCanonicalCondition null (everything else)
 
 import argparse
 import sys
+from typing import List, Optional
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v17.common.types.criteria import (
+    ListingDimensionInfo,
+    ListingGroupInfo,
+    ProductBrandInfo,
+    ProductConditionInfo,
+)
+from google.ads.googleads.v17.enums.types.ad_group_criterion_status import (
+    AdGroupCriterionStatusEnum,
+)
+from google.ads.googleads.v17.enums.types.listing_group_type import (
+    ListingGroupTypeEnum,
+)
+from google.ads.googleads.v17.enums.types.product_condition import (
+    ProductConditionEnum,
+)
+from google.ads.googleads.v17.resources.types.ad_group_criterion import (
+    AdGroupCriterion,
+)
+from google.ads.googleads.v17.services.services.ad_group_criterion_service import (
+    AdGroupCriterionServiceClient,
+)
+from google.ads.googleads.v17.services.services.ad_group_service import (
+    AdGroupServiceClient,
+)
+from google.ads.googleads.v17.services.services.google_ads_service import (
+    GoogleAdsServiceClient,
+)
+from google.ads.googleads.v17.services.types.ad_group_criterion_operation import (
+    AdGroupCriterionOperation,
+)
+from google.ads.googleads.v17.services.types.google_ads_service import (
+    MutateGoogleAdsResponse,
+    SearchGoogleAdsResponse,
+)
 
-last_criterion_id = 0
+last_criterion_id: int = 0
 
 
-def next_id():
+def next_id() -> str:
     """Returns a decreasing negative number for temporary ad group criteria IDs.
 
     The ad group criteria will get real IDs when created on the server.
@@ -49,7 +84,12 @@ def next_id():
 
 
 # [START add_shopping_product_listing_group_tree]
-def main(client, customer_id, ad_group_id, replace_existing_tree):
+def main(
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+    replace_existing_tree: bool,
+) -> None:
     """Adds a shopping listing group tree to a shopping ad group.
 
     Args:
@@ -60,7 +100,9 @@ def main(client, customer_id, ad_group_id, replace_existing_tree):
             group tree on the ad group. Defaults to false.
     """
     # Get the AdGroupCriterionService client.
-    ad_group_criterion_service = client.get_service("AdGroupCriterionService")
+    ad_group_criterion_service: AdGroupCriterionServiceClient = (
+        client.get_service("AdGroupCriterionService")
+    )
 
     # Optional: Remove the existing listing group tree, if it already exists
     # on the ad group. The example will throw a LISTING_GROUP_ALREADY_EXISTS
@@ -70,25 +112,29 @@ def main(client, customer_id, ad_group_id, replace_existing_tree):
         remove_listing_group_tree(client, customer_id, ad_group_id)
 
     # Create a list of ad group criteria operations.
-    operations = []
+    operations: List[AdGroupCriterionOperation] = []
 
     # Construct the listing group tree "root" node.
     # Subdivision node: (Root node)
-    ad_group_criterion_root_operation = create_listing_group_subdivision(
-        client, customer_id, ad_group_id
+    ad_group_criterion_root_operation: AdGroupCriterionOperation = (
+        create_listing_group_subdivision(client, customer_id, ad_group_id)
     )
 
     # Get the resource name that will be used for the root node.
     # This resource has not been created yet and will include the temporary
     # ID as part of the criterion ID.
-    ad_group_criterion_root_resource_name = (
+    ad_group_criterion_root_resource_name: str = (
         ad_group_criterion_root_operation.create.resource_name
     )
     operations.append(ad_group_criterion_root_operation)
 
     # Construct the listing group unit nodes for NEW, USED, and other.
-    product_condition_enum = client.enums.ProductConditionEnum
-    condition_dimension_info = client.get_type("ListingDimensionInfo")
+    product_condition_enum: ProductConditionEnum = (
+        client.enums.ProductConditionEnum
+    )
+    condition_dimension_info: ListingDimensionInfo = client.get_type(
+        "ListingDimensionInfo"
+    )
 
     # Biddable Unit node: (Condition NEW node)
     # * Product Condition: NEW
@@ -132,23 +178,27 @@ def main(client, customer_id, ad_group_id, replace_existing_tree):
         condition_dimension_info.product_condition,
         client.get_type("ProductConditionInfo"),
     )
-    ad_group_criterion_other_operation = create_listing_group_subdivision(
-        client,
-        customer_id,
-        ad_group_id,
-        ad_group_criterion_root_resource_name,
-        condition_dimension_info,
+    ad_group_criterion_other_operation: AdGroupCriterionOperation = (
+        create_listing_group_subdivision(
+            client,
+            customer_id,
+            ad_group_id,
+            ad_group_criterion_root_resource_name,
+            condition_dimension_info,
+        )
     )
     # Get the resource name that will be used for the condition other node.
     # This resource has not been created yet and will include the temporary
     # ID as part of the criterion ID.
-    ad_group_criterion_other_resource_name = (
+    ad_group_criterion_other_resource_name: str = (
         ad_group_criterion_other_operation.create.resource_name
     )
     operations.append(ad_group_criterion_other_operation)
 
     # Build the listing group nodes for CoolBrand, CheapBrand, and other.
-    brand_dimension_info = client.get_type("ListingDimensionInfo")
+    brand_dimension_info: ListingDimensionInfo = client.get_type(
+        "ListingDimensionInfo"
+    )
 
     # Biddable Unit node: (Brand CoolBrand node)
     # * Brand: CoolBrand
@@ -198,7 +248,7 @@ def main(client, customer_id, ad_group_id, replace_existing_tree):
     )
 
     # Add the ad group criteria.
-    mutate_ad_group_criteria_response = (
+    mutate_ad_group_criteria_response: MutateGoogleAdsResponse = (
         ad_group_criterion_service.mutate_ad_group_criteria(
             customer_id=customer_id, operations=operations
         )
@@ -216,7 +266,11 @@ def main(client, customer_id, ad_group_id, replace_existing_tree):
     # [END add_shopping_product_listing_group_tree]
 
 
-def remove_listing_group_tree(client, customer_id, ad_group_id):
+def remove_listing_group_tree(
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+) -> None:
     """Removes ad group criteria for an ad group's existing listing group tree.
 
     Args:
@@ -226,13 +280,16 @@ def remove_listing_group_tree(client, customer_id, ad_group_id):
             tree.
     """
     # Get the GoogleAdsService client.
-    googleads_service = client.get_service("GoogleAdsService")
+    googleads_service: GoogleAdsServiceClient = client.get_service(
+        "GoogleAdsService"
+    )
 
     print("Removing existing listing group tree...")
     # Create a search Google Ads request that will retrieve all listing groups
     # where the parent ad group criterion is NULL (and hence the root node in
     # the tree) for a given ad group id.
-    query = f"""
+    # Note: ad_group_id is used as an int in the query.
+    query: str = f"""
         SELECT ad_group_criterion.resource_name
         FROM ad_group_criterion
         WHERE
@@ -240,40 +297,45 @@ def remove_listing_group_tree(client, customer_id, ad_group_id):
           AND ad_group_criterion.listing_group.parent_ad_group_criterion IS NULL
           AND ad_group.id = {ad_group_id}"""
 
-    results = googleads_service.search(customer_id=customer_id, query=query)
-    ad_group_criterion_operations = []
+    results: SearchGoogleAdsResponse = googleads_service.search(
+        customer_id=customer_id, query=query
+    )
+    ad_group_criterion_operations: List[AdGroupCriterionOperation] = []
 
     # Iterate over all rows to find the ad group criteria to remove.
     for row in results:
-        criterion = row.ad_group_criterion
+        criterion: AdGroupCriterion = row.ad_group_criterion
         print(
             "Found an ad group criterion with resource name: "
             f"'{criterion.resource_name}'."
         )
-        ad_group_criterion_operation = client.get_type(
-            "AdGroupCriterionOperation"
+        ad_group_criterion_operation: AdGroupCriterionOperation = (
+            client.get_type("AdGroupCriterionOperation")
         )
         ad_group_criterion_operation.remove = criterion.resource_name
         ad_group_criterion_operations.append(ad_group_criterion_operation)
 
     if ad_group_criterion_operations:
         # Remove the ad group criteria that define the listing group tree.
-        ad_group_criterion_service = client.get_service(
-            "AdGroupCriterionService"
+        ad_group_criterion_service: AdGroupCriterionServiceClient = (
+            client.get_service("AdGroupCriterionService")
         )
-        response = ad_group_criterion_service.mutate_ad_group_criteria(
-            customer_id=customer_id, operations=ad_group_criterion_operations
+        response: MutateGoogleAdsResponse = (
+            ad_group_criterion_service.mutate_ad_group_criteria(
+                customer_id=customer_id,
+                operations=ad_group_criterion_operations,
+            )
         )
         print(f"Removed {len(response.results)} ad group criteria.")
 
 
 def create_listing_group_subdivision(
-    client,
-    customer_id,
-    ad_group_id,
-    parent_ad_group_criterion_resource_name=None,
-    listing_dimension_info=None,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+    parent_ad_group_criterion_resource_name: Optional[str] = None,
+    listing_dimension_info: Optional[ListingDimensionInfo] = None,
+) -> AdGroupCriterionOperation:
     """Creates a new criterion containing a subdivision listing group node.
 
     If the parent ad group criterion resource name or listing dimension info are
@@ -292,16 +354,25 @@ def create_listing_group_subdivision(
         An AdGroupCriterionOperation containing a populated ad group criterion.
     """
     # Create an ad group criterion operation and populate the criterion.
-    operation = client.get_type("AdGroupCriterionOperation")
-    ad_group_criterion = operation.create
+    operation: AdGroupCriterionOperation = client.get_type(
+        "AdGroupCriterionOperation"
+    )
+    ad_group_criterion: AdGroupCriterion = operation.create
+    ad_group_criterion_service: AdGroupCriterionServiceClient = (
+        client.get_service("AdGroupCriterionService")
+    )
     # The resource name the criterion will be created with. This will define
     # the ID for the ad group criterion.
-    ad_group_criterion.resource_name = client.get_service(
-        "AdGroupCriterionService"
-    ).ad_group_criterion_path(customer_id, ad_group_id, next_id())
-    ad_group_criterion.status = client.enums.AdGroupCriterionStatusEnum.ENABLED
+    ad_group_criterion.resource_name = (
+        ad_group_criterion_service.ad_group_criterion_path(
+            customer_id, ad_group_id, next_id()
+        )
+    )
+    ad_group_criterion.status = (
+        client.enums.AdGroupCriterionStatusEnum.ENABLED
+    )
 
-    listing_group_info = ad_group_criterion.listing_group
+    listing_group_info: ListingGroupInfo = ad_group_criterion.listing_group
     # Set the type as a SUBDIVISION, which will allow the node to be the
     # parent of another sub-tree.
     listing_group_info.type_ = client.enums.ListingGroupTypeEnum.SUBDIVISION
@@ -310,7 +381,7 @@ def create_listing_group_subdivision(
     # value.
     if (
         parent_ad_group_criterion_resource_name
-        and listing_dimension_info != None
+        and listing_dimension_info is not None
     ):
         # Set the ad group criterion resource name for the parent listing group.
         # This can include a temporary ID if the parent criterion is not yet
@@ -326,13 +397,13 @@ def create_listing_group_subdivision(
 
 
 def create_listing_group_unit_biddable(
-    client,
-    customer_id,
-    ad_group_id,
-    parent_ad_group_criterion_resource_name,
-    listing_dimension_info,
-    cpc_bid_micros=None,
-):
+    client: GoogleAdsClient,
+    customer_id: str,
+    ad_group_id: str,
+    parent_ad_group_criterion_resource_name: str,
+    listing_dimension_info: ListingDimensionInfo,
+    cpc_bid_micros: Optional[int] = None,
+) -> AdGroupCriterionOperation:
     """Creates a new criterion containing a biddable unit listing group node.
 
     Args:
@@ -356,10 +427,15 @@ def create_listing_group_unit_biddable(
     # In both cases you must set the parent ad group criterion's resource name
     # on the listing group for non-root nodes.
     # This example demonstrates method (1).
-    operation = client.get_type("AdGroupCriterionOperation")
+    operation: AdGroupCriterionOperation = client.get_type(
+        "AdGroupCriterionOperation"
+    )
 
-    criterion = operation.create
-    criterion.ad_group = client.get_service("AdGroupService").ad_group_path(
+    criterion: AdGroupCriterion = operation.create
+    ad_group_service: AdGroupServiceClient = client.get_service(
+        "AdGroupService"
+    )
+    criterion.ad_group = ad_group_service.ad_group_path(
         customer_id, ad_group_id
     )
     criterion.status = client.enums.AdGroupCriterionStatusEnum.ENABLED
@@ -369,7 +445,7 @@ def create_listing_group_unit_biddable(
     if cpc_bid_micros:
         criterion.cpc_bid_micros = cpc_bid_micros
 
-    listing_group = criterion.listing_group
+    listing_group: ListingGroupInfo = criterion.listing_group
     # Set the type as a UNIT, which will allow the group to be biddable.
     listing_group.type_ = client.enums.ListingGroupTypeEnum.UNIT
     # Set the ad group criterion resource name for the parent listing group.
@@ -378,7 +454,7 @@ def create_listing_group_unit_biddable(
         parent_ad_group_criterion_resource_name
     )
     # Case values contain the listing dimension used for the node.
-    if listing_dimension_info != None:
+    if listing_dimension_info is not None:
         client.copy_from(listing_group.case_value, listing_dimension_info)
 
     return operation
@@ -414,11 +490,13 @@ if __name__ == "__main__":
         "the ad group if one already exists. Defaults to false.",
     )
 
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(

--- a/examples/shopping_ads/get_product_category_constants.py
+++ b/examples/shopping_ads/get_product_category_constants.py
@@ -18,11 +18,38 @@
 import argparse
 import collections
 import sys
+from typing import DefaultDict, List, Optional, Any
+
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v17.resources.types.product_category_constant import (
+    ProductCategoryConstant,
+)
+from google.ads.googleads.v17.services.services.google_ads_service import (
+    GoogleAdsServiceClient,
+)
+from google.ads.googleads.v17.services.types.google_ads_service import (
+    SearchGoogleAdsStreamRequest,
+    SearchGoogleAdsStreamResponse,
+)
 
 
-def display_categories(categories, prefix=""):
+class Category:
+    def __init__(
+        self,
+        localized_name: Optional[str] = None,
+        resource_name: Optional[str] = None,
+        children: Optional[List["Category"]] = None,
+    ) -> None:
+        self.localized_name: Optional[str] = localized_name
+        self.resource_name: Optional[str] = resource_name
+        if children is None:
+            self.children: List["Category"] = []
+        else:
+            self.children: List["Category"] = children
+
+
+def display_categories(categories: List[Category], prefix: str = "") -> None:
     """Recursively prints out each category and its children.
 
     Args:
@@ -39,67 +66,69 @@ def display_categories(categories, prefix=""):
             )
 
 
-def main(client, customer_id):
+def main(client: GoogleAdsClient, customer_id: str) -> None:
     """Fetches the set of valid ProductBiddingCategories."""
 
-    class Category:
-        def __init__(
-            self, localized_name=None, resource_name=None, children=None
-        ):
-            self.localized_name = localized_name
-            self.resource_name = resource_name
-            if children is None:
-                self.children = []
-            else:
-                self.children = children
-
-    ga_service = client.get_service("GoogleAdsService")
-    query = """
+    ga_service: GoogleAdsServiceClient = client.get_service("GoogleAdsService")
+    query: str = """
         SELECT
             product_category_constant.localizations,
             product_category_constant.product_category_constant_parent
         FROM product_category_constant"""
 
-    search_request = client.get_type("SearchGoogleAdsStreamRequest")
+    search_request: SearchGoogleAdsStreamRequest = client.get_type(
+        "SearchGoogleAdsStreamRequest"
+    )
     search_request.customer_id = customer_id
     search_request.query = query
-    stream = ga_service.search_stream(search_request)
+    stream: SearchGoogleAdsStreamResponse = ga_service.search_stream(
+        search_request
+    )
 
-    all_categories = collections.defaultdict(lambda: Category())
+    all_categories: DefaultDict[str, Category] = collections.defaultdict(
+        lambda: Category()
+    )
 
     # Creates a map of top level categories.
-    root_categories = []
+    root_categories: List[Category] = []
 
     for batch in stream:
         for row in batch.results:
             # Gets the product category constant from the row.
-            product_category = row.product_category_constant
+            product_category: ProductCategoryConstant = (
+                row.product_category_constant
+            )
 
-            localized_name = ""
+            localized_name: str = ""
             for localization in product_category.localizations:
-                region = localization.region_code
-                lang = localization.language_code
+                region: str = localization.region_code
+                lang: str = localization.language_code
                 if region == "US" and lang == "en":
                     # Gets the name from the product category localization.
                     localized_name = localization.value
                     break
 
-            category = Category(
+            category: Category = Category(
                 localized_name=localized_name,
                 resource_name=product_category.resource_name,
             )
 
-            all_categories[category.resource_name] = category
-            parent_resource_name = (
-                product_category.product_category_constant_parent
-            )
+            # Ensure resource_name is not None before using as a dict key
+            if category.resource_name:
+                all_categories[category.resource_name] = category
+
+            parent_resource_name: Optional[str] = None
+            if product_category.product_category_constant_parent:
+                parent_resource_name = (
+                    product_category.product_category_constant_parent
+                )
 
             # Links the category to the parent category if any.
             if parent_resource_name:
                 # Adds the category as a child category of the parent
                 # category.
                 all_categories[parent_resource_name].children.append(category)
-            else:
+            elif category.resource_name: # Ensure it's not None before adding to root
                 # Otherwise adds the category as a root category.
                 root_categories.append(category)
 
@@ -118,11 +147,13 @@ if __name__ == "__main__":
         required=True,
         help="The Google Ads customer ID.",
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # GoogleAdsClient will read the google-ads.yaml configuration file in the
     # home directory if none is specified.
-    googleads_client = GoogleAdsClient.load_from_storage(version="v19")
+    googleads_client: GoogleAdsClient = GoogleAdsClient.load_from_storage(
+        version="v19"
+    )
 
     try:
         main(googleads_client, args.customer_id)


### PR DESCRIPTION
This change adds type annotations to all Python files within the examples/shopping_ads directory.

Type hints were added for function arguments, return values, class attributes, and local variables to improve code clarity, maintainability, and enable static analysis.