### PR TITLE
Gold test for examples/billing

### DIFF
--- a/examples/billing/get_invoices.py
+++ b/examples/billing/get_invoices.py
@@ -63,18 +63,18 @@ def main(client, customer_id, billing_setup_id):
     Currency code: {invoice.currency_code}
     Service date range (inclusive): from {invoice.service_date_range.start_date} to {invoice.service_date_range.end_date}
     Adjustments:
-        subtotal {_micros_to_currency(invoice.adjustments_subtotal_amount_micros)}
-        tax {_micros_to_currency(invoice.adjustments_tax_amount_micros)}
-        total {_micros_to_currency(invoice.adjustments_total_amount_micros)}
+        subtotal {micros_to_currency(invoice.adjustments_subtotal_amount_micros)}
+        tax {micros_to_currency(invoice.adjustments_tax_amount_micros)}
+        total {micros_to_currency(invoice.adjustments_total_amount_micros)}
     Regulatory costs:
-        subtotal {_micros_to_currency(invoice.regulatory_costs_subtotal_amount_micros)}
-        tax {_micros_to_currency(invoice.regulatory_costs_tax_amount_micros)}
-        total {_micros_to_currency(invoice.regulatory_costs_total_amount_micros)}
+        subtotal {micros_to_currency(invoice.regulatory_costs_subtotal_amount_micros)}
+        tax {micros_to_currency(invoice.regulatory_costs_tax_amount_micros)}
+        total {micros_to_currency(invoice.regulatory_costs_total_amount_micros)}
     Replaced invoices: {invoice.replaced_invoices.join(", ") if invoice.replaced_invoices else "none"}
     Amounts:
-        subtotal {_micros_to_currency(invoice.subtotal_amount_micros)}
-        tax {_micros_to_currency(invoice.tax_amount_micros)}
-        total {_micros_to_currency(invoice.total_amount_micros)}
+        subtotal {micros_to_currency(invoice.subtotal_amount_micros)}
+        tax {micros_to_currency(invoice.tax_amount_micros)}
+        total {micros_to_currency(invoice.total_amount_micros)}
     Corrected invoice: {invoice.corrected_invoice or "none"}
     PDF URL: {invoice.pdf_url}
     Account budgets:
@@ -92,9 +92,9 @@ def main(client, customer_id, billing_setup_id):
                         from #{account_budget_summary.billable_activity_date_range.start_date}
                         to #{account_budget_summary.billable_activity_date_range.end_date}
                       Amounts:
-                        subtotal '{_micros_to_currency(account_budget_summary.subtotal_amount_micros)}'
-                        tax '{_micros_to_currency(account_budget_summary.tax_amount_micros)}'
-                        total '{_micros_to_currency(account_budget_summary.total_amount_micros)}'
+                        subtotal '{micros_to_currency(account_budget_summary.subtotal_amount_micros)}'
+                        tax '{micros_to_currency(account_budget_summary.tax_amount_micros)}'
+                        total '{micros_to_currency(account_budget_summary.total_amount_micros)}'
                 """
             )
             # [END get_invoices_1]

--- a/examples/billing/tests/test_add_account_budget_proposal.py
+++ b/examples/billing/tests/test_add_account_budget_proposal.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+from io import StringIO
+
+from examples.billing.add_account_budget_proposal import main
+
+class TestAddAccountBudgetProposal(unittest.TestCase):
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_function(self, mock_stdout):
+        # Mock GoogleAdsClient instance and its services/types/enums
+        mock_client = MagicMock()
+        mock_proposal_service = MagicMock()
+        mock_billing_setup_service = MagicMock()
+        mock_operation_type = MagicMock()
+        mock_proposal_create_obj = MagicMock() # This will be operation.create
+
+        # Configure client.get_service
+        def get_service_side_effect(service_name):
+            if service_name == "AccountBudgetProposalService":
+                return mock_proposal_service
+            elif service_name == "BillingSetupService":
+                return mock_billing_setup_service
+            return MagicMock() # Default mock for other services if any
+        mock_client.get_service.side_effect = get_service_side_effect
+
+        # Configure client.get_type for AccountBudgetProposalOperation
+        mock_client.get_type.return_value = mock_operation_type
+        # Configure the .create attribute of the operation type
+        mock_operation_type.create = mock_proposal_create_obj
+
+        # Configure enums
+        mock_client.enums.AccountBudgetProposalTypeEnum.CREATE = "CREATE_ENUM_VAL"
+        mock_client.enums.TimeTypeEnum.NOW = "NOW_ENUM_VAL"
+        mock_client.enums.TimeTypeEnum.FOREVER = "FOREVER_ENUM_VAL"
+
+        # Configure billing_setup_service.billing_setup_path
+        expected_billing_setup_path = "customers/123/billingSetups/456"
+        mock_billing_setup_service.billing_setup_path.return_value = expected_billing_setup_path
+
+        # Configure response from mutate_account_budget_proposal
+        mock_mutate_response = MagicMock()
+        expected_proposal_resource_name = "customers/123/accountBudgetProposals/789"
+        mock_mutate_response.result.resource_name = expected_proposal_resource_name
+        mock_proposal_service.mutate_account_budget_proposal.return_value = mock_mutate_response
+
+        # Test data
+        customer_id = "123"
+        billing_setup_id = "456"
+
+        # Call the main function
+        main(mock_client, customer_id, billing_setup_id)
+
+        # --- Assertions ---
+
+        # Assert get_service calls
+        mock_client.get_service.assert_any_call("AccountBudgetProposalService")
+        mock_client.get_service.assert_any_call("BillingSetupService")
+
+        # Assert get_type call
+        mock_client.get_type.assert_called_once_with("AccountBudgetProposalOperation")
+
+        # Assert billing_setup_path call
+        mock_billing_setup_service.billing_setup_path.assert_called_once_with(customer_id, billing_setup_id)
+
+        # Assert that the attributes of the proposal object (mock_proposal_create_obj) were set correctly
+        self.assertEqual(mock_proposal_create_obj.proposal_type, "CREATE_ENUM_VAL")
+        self.assertEqual(mock_proposal_create_obj.billing_setup, expected_billing_setup_path)
+        self.assertEqual(mock_proposal_create_obj.proposed_name, "Account Budget Proposal (example)")
+        self.assertEqual(mock_proposal_create_obj.proposed_start_time_type, "NOW_ENUM_VAL")
+        self.assertEqual(mock_proposal_create_obj.proposed_end_time_type, "FOREVER_ENUM_VAL")
+        self.assertEqual(mock_proposal_create_obj.proposed_spending_limit_micros, 10000)
+        # self.assertEqual(mock_proposal_create_obj.proposed_notes, 'Received prepayment of $0.01') # If notes were set
+
+        # Assert mutate_account_budget_proposal call
+        mock_proposal_service.mutate_account_budget_proposal.assert_called_once_with(
+            customer_id=customer_id,
+            operation=mock_operation_type, # The operation object itself was passed
+        )
+
+        # Assert output
+        expected_output = f'Created account budget proposal "{expected_proposal_resource_name}".\n'
+        self.assertEqual(mock_stdout.getvalue(), expected_output)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/billing/tests/test_add_billing_setup.py
+++ b/examples/billing/tests/test_add_billing_setup.py
@@ -1,0 +1,214 @@
+import unittest
+from unittest.mock import MagicMock, patch, call # Ensure call is imported
+from io import StringIO
+from datetime import datetime, timedelta
+import uuid
+
+from examples.billing.add_billing_setup import (
+    main,
+    create_billing_setup,
+    set_billing_setup_date_times,
+)
+
+class TestAddBillingSetup(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.customer_id = "12345"
+
+    def test_create_billing_setup_with_payments_account_id(self):
+        payments_account_id = "1111-2222-3333-4444"
+        expected_payments_account_path = f"customers/{self.customer_id}/paymentsAccounts/{payments_account_id}"
+
+        mock_billing_setup_obj = MagicMock(name="BillingSetupInstance")
+        # payments_account_info will be auto-created by MagicMock if accessed.
+        # We want to check that no attributes *on* payments_account_info are set by the SUT.
+        mock_billing_setup_obj.payments_account_info = MagicMock(name="PaymentsAccountInfoOnBillingSetup")
+
+        self.mock_client.get_type.return_value = mock_billing_setup_obj
+
+        mock_billing_setup_service_for_path = MagicMock()
+        mock_billing_setup_service_for_path.payments_account_path.return_value = expected_payments_account_path
+
+        original_get_service = self.mock_client.get_service
+        def side_effect_get_service(service_name):
+            if service_name == "BillingSetupService":
+                return mock_billing_setup_service_for_path
+            return MagicMock()
+
+        with patch.object(self.mock_client, 'get_service', side_effect=side_effect_get_service):
+            billing_setup_obj_returned = create_billing_setup(
+                self.mock_client, self.customer_id, payments_account_id=payments_account_id
+            )
+
+        self.mock_client.get_type.assert_called_once_with("BillingSetup")
+        self.assertEqual(billing_setup_obj_returned, mock_billing_setup_obj)
+        self.assertEqual(billing_setup_obj_returned.payments_account, expected_payments_account_path)
+        mock_billing_setup_service_for_path.payments_account_path.assert_called_once_with(
+            self.customer_id, payments_account_id
+        )
+
+        # Check that attributes on payments_account_info were not set.
+        # mock_calls records calls like obj.attr = value as ('__setattr__', ('attr', value))
+        for call_obj in mock_billing_setup_obj.payments_account_info.mock_calls:
+            if call_obj[0] == '__setattr__':
+                self.assertNotIn(call_obj[1][0], ['payments_account_name', 'payments_profile_id'],
+                                 f"Attribute {call_obj[1][0]} should not have been set on payments_account_info")
+
+    @patch('examples.billing.add_billing_setup.uuid4')
+    def test_create_billing_setup_with_payments_profile_id(self, mock_uuid4):
+        payments_profile_id = "PROFILE-123"
+        mock_uuid_obj = MagicMock()
+        mock_uuid_obj.__str__.return_value = "mock-uuid-123"
+        mock_uuid4.return_value = mock_uuid_obj
+
+        mock_billing_setup_obj = MagicMock(name="BillingSetupInstance")
+        mock_billing_setup_obj.payments_account_info = MagicMock(name="PaymentsAccountInfoInstance")
+        # Ensure payments_account is not on the mock initially, so hasattr can be used.
+        if hasattr(mock_billing_setup_obj, 'payments_account'):
+             delattr(mock_billing_setup_obj, 'payments_account') # Make hasattr work reliably
+
+        self.mock_client.get_type.return_value = mock_billing_setup_obj
+
+        billing_setup_obj_returned = create_billing_setup(
+            self.mock_client, self.customer_id, payments_profile_id=payments_profile_id
+        )
+
+        self.mock_client.get_type.assert_called_once_with("BillingSetup")
+        self.assertEqual(billing_setup_obj_returned, mock_billing_setup_obj)
+        self.assertEqual(billing_setup_obj_returned.payments_account_info.payments_account_name, f"Payments Account #mock-uuid-123")
+        self.assertEqual(billing_setup_obj_returned.payments_account_info.payments_profile_id, payments_profile_id)
+
+        # Check that payments_account was not set by the SUT.
+        # If it was never set by SUT, hasattr should be False (after our delattr).
+        self.assertFalse(hasattr(mock_billing_setup_obj, 'payments_account'),
+                         "payments_account attribute should not be set when payments_profile_id is used.")
+
+    @patch('examples.billing.add_billing_setup.datetime')
+    def test_set_billing_setup_date_times_no_existing_setup(self, mock_dt_module):
+        mock_now = datetime(2023, 1, 1, 12, 0, 0)
+        mock_dt_module.now.return_value = mock_now
+
+        mock_billing_setup_instance = MagicMock()
+        mock_ga_service = MagicMock()
+        self.mock_client.get_service.return_value = mock_ga_service
+        mock_ga_service.search_stream.return_value = iter([])
+
+        set_billing_setup_date_times(self.mock_client, self.customer_id, mock_billing_setup_instance)
+
+        self.mock_client.get_service.assert_called_once_with("GoogleAdsService")
+        mock_ga_service.search_stream.assert_called_once()
+        expected_start_datetime_str = mock_now.strftime("%Y-%m-%d %H:%M:%S")
+        expected_end_datetime_str = (mock_now + timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        self.assertEqual(mock_billing_setup_instance.start_date_time, expected_start_datetime_str)
+        self.assertEqual(mock_billing_setup_instance.end_date_time, expected_end_datetime_str)
+
+    def test_set_billing_setup_date_times_existing_with_end_date_full_format(self):
+        mock_billing_setup_instance = MagicMock()
+        mock_ga_service = MagicMock()
+        self.mock_client.get_service.return_value = mock_ga_service
+
+        mock_row = MagicMock()
+        mock_row.billing_setup.end_date_time = "2023-01-15 10:00:00"
+        mock_batch = MagicMock()
+        mock_batch.results = [mock_row]
+        mock_ga_service.search_stream.return_value = iter([mock_batch])
+
+        set_billing_setup_date_times(self.mock_client, self.customer_id, mock_billing_setup_instance)
+
+        expected_start_date = datetime(2023, 1, 15, 10, 0, 0) + timedelta(days=1)
+        expected_start_datetime_str = expected_start_date.strftime("%Y-%m-%d %H:%M:%S")
+        expected_end_datetime_str = (expected_start_date + timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        self.assertEqual(mock_billing_setup_instance.start_date_time, expected_start_datetime_str)
+        self.assertEqual(mock_billing_setup_instance.end_date_time, expected_end_datetime_str)
+
+    def test_set_billing_setup_date_times_existing_with_end_date_only_format(self):
+        mock_billing_setup_instance = MagicMock()
+        mock_ga_service = MagicMock()
+        self.mock_client.get_service.return_value = mock_ga_service
+
+        mock_row = MagicMock()
+        mock_row.billing_setup.end_date_time = "2023-01-20"
+        mock_batch = MagicMock()
+        mock_batch.results = [mock_row]
+        mock_ga_service.search_stream.return_value = iter([mock_batch])
+
+        set_billing_setup_date_times(self.mock_client, self.customer_id, mock_billing_setup_instance)
+
+        expected_start_date = datetime(2023, 1, 20, 0, 0, 0) + timedelta(days=1)
+        expected_start_datetime_str = expected_start_date.strftime("%Y-%m-%d %H:%M:%S")
+        expected_end_datetime_str = (expected_start_date + timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+        self.assertEqual(mock_billing_setup_instance.start_date_time, expected_start_datetime_str)
+        self.assertEqual(mock_billing_setup_instance.end_date_time, expected_end_datetime_str)
+
+    def test_set_billing_setup_date_times_existing_runs_forever(self):
+        mock_billing_setup_instance = MagicMock()
+        mock_ga_service = MagicMock()
+        self.mock_client.get_service.return_value = mock_ga_service
+
+        mock_row = MagicMock()
+        mock_row.billing_setup.end_date_time = None
+        mock_batch = MagicMock()
+        mock_batch.results = [mock_row]
+        mock_ga_service.search_stream.return_value = iter([mock_batch])
+
+        with self.assertRaisesRegex(Exception, "latest existing billing setup is set to run indefinitely"):
+            set_billing_setup_date_times(self.mock_client, self.customer_id, mock_billing_setup_instance)
+
+    @patch('examples.billing.add_billing_setup.create_billing_setup')
+    @patch('examples.billing.add_billing_setup.set_billing_setup_date_times')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_function_with_payments_account_id(self, mock_stdout, mock_set_dates, mock_create_setup):
+        self.mock_client.reset_mock()
+
+        mock_created_billing_setup = MagicMock(name="MockedBillingSetupInstance")
+        mock_create_setup.return_value = mock_created_billing_setup
+
+        mock_billing_setup_service_main = MagicMock(name="BillingSetupServiceForMain")
+        mock_operation_type_main = MagicMock(name="BillingSetupOperationForMain")
+        mock_operation_type_main.create = MagicMock(name="OperationCreate")
+
+        def main_get_service_side_effect(service_name):
+            if service_name == "BillingSetupService":
+                return mock_billing_setup_service_main
+            return MagicMock()
+        self.mock_client.get_service.side_effect = main_get_service_side_effect
+
+        def main_get_type_side_effect(type_name):
+            if type_name == "BillingSetupOperation":
+                return mock_operation_type_main
+            return MagicMock()
+        self.mock_client.get_type.side_effect = main_get_type_side_effect
+
+        mock_mutate_response = MagicMock()
+        expected_resource_name = f"customers/{self.customer_id}/billingSetups/789"
+        mock_mutate_response.result.resource_name = expected_resource_name
+        mock_billing_setup_service_main.mutate_billing_setup.return_value = mock_mutate_response
+
+        payments_account_id_for_main = "PAY_ACC_ID_MAIN"
+        main(self.mock_client, self.customer_id, payments_account_id=payments_account_id_for_main)
+
+        mock_create_setup.assert_called_once_with(
+            self.mock_client, self.customer_id, payments_account_id_for_main, None
+        )
+        mock_set_dates.assert_called_once_with(
+            self.mock_client, self.customer_id, mock_created_billing_setup
+        )
+        self.mock_client.get_type.assert_called_once_with("BillingSetupOperation")
+        self.mock_client.copy_from.assert_called_once_with(
+            mock_operation_type_main.create, mock_created_billing_setup
+        )
+        self.mock_client.get_service.assert_called_once_with("BillingSetupService")
+        mock_billing_setup_service_main.mutate_billing_setup.assert_called_once_with(
+            customer_id=self.customer_id, operation=mock_operation_type_main
+        )
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            f"Added new billing setup with resource name {expected_resource_name}\n"
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/billing/tests/test_get_invoices.py
+++ b/examples/billing/tests/test_get_invoices.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from io import StringIO
+from datetime import date, timedelta
+
+from examples.billing import get_invoices
+
+def micros_to_currency_for_test(micros):
+    return micros / 1000000.0 if micros is not None else None
+
+class TestGetInvoices(unittest.TestCase):
+
+    # Decorators are applied bottom-up.
+    # Innermost: @patch('sys.stdout', new_callable=StringIO) -> mock_stdout (arg 1)
+    # Middle:    @patch('examples.billing.get_invoices.GoogleAdsClient') -> mock_google_ads_client_class_in_module (arg 2)
+    # Outermost: @patch('examples.billing.get_invoices.micros_to_currency', new=micros_to_currency_for_test) -> NO ARG ADDED
+    @patch('examples.billing.get_invoices.micros_to_currency', new=micros_to_currency_for_test)
+    @patch('examples.billing.get_invoices.GoogleAdsClient')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_function(self, mock_stdout, mock_google_ads_client_class_in_module): # Corrected signature
+
+        mock_client_instance = MagicMock()
+        mock_invoice_service = MagicMock()
+        mock_google_ads_service = MagicMock()
+
+        mock_client_instance.get_service.side_effect = lambda service_name: {
+            "InvoiceService": mock_invoice_service,
+            "GoogleAdsService": mock_google_ads_service
+        }.get(service_name)
+
+        # mock_google_ads_client_class_in_module is the mock for GoogleAdsClient in the get_invoices module
+        # This is correctly passed due to the @patch decorator.
+
+        # micros_to_currency is patched with 'new', so no mock object is passed for it.
+        # Calls to get_invoices.micros_to_currency will use micros_to_currency_for_test.
+
+        mock_google_ads_service.billing_setup_path.return_value = "customers/12345/billingSetups/67890"
+        mock_invoice = MagicMock()
+        mock_invoice.resource_name = "customers/12345/invoices/INV001"
+        mock_invoice.id = "INV001_ID"
+        mock_invoice.type_ = "INVOICE_TYPE_CREDIT"
+        mock_invoice.billing_setup = "customers/12345/billingSetups/67890"
+        mock_invoice.payments_account_id = "PAY_ACC_ID_001"
+        mock_invoice.payments_profile_id = "PAY_PROF_ID_001"
+        mock_invoice.issue_date = "2023-10-15"
+        mock_invoice.due_date = "2023-11-15"
+        mock_invoice.currency_code = "USD"
+        mock_invoice.service_date_range = MagicMock()
+        mock_invoice.service_date_range.start_date = "2023-10-01"
+        mock_invoice.service_date_range.end_date = "2023-10-31"
+        mock_invoice.adjustments_subtotal_amount_micros = 1000000
+        mock_invoice.adjustments_tax_amount_micros = 200000
+        mock_invoice.adjustments_total_amount_micros = 1200000
+        mock_invoice.regulatory_costs_subtotal_amount_micros = 50000
+        mock_invoice.regulatory_costs_tax_amount_micros = 10000
+        mock_invoice.regulatory_costs_total_amount_micros = 60000
+
+        mock_replaced_invoices_list = ["customers/12345/invoices/OLD_INV"]
+        mock_invoice.replaced_invoices = MagicMock()
+        mock_invoice.replaced_invoices.__bool__.return_value = bool(mock_replaced_invoices_list)
+        mock_invoice.replaced_invoices.join.return_value = ", ".join(mock_replaced_invoices_list)
+
+        mock_invoice.subtotal_amount_micros = 20000000
+        mock_invoice.tax_amount_micros = 4000000
+        mock_invoice.total_amount_micros = 24000000
+        mock_invoice.corrected_invoice = None
+        mock_invoice.pdf_url = "http://example.com/invoice.pdf"
+
+        mock_account_budget_summary = MagicMock()
+        mock_account_budget_summary.account_budget = "customers/12345/accountBudgets/AB001"
+        mock_account_budget_summary.account_budget_name = "Test Budget"
+        mock_account_budget_summary.customer = "customers/12345"
+        mock_account_budget_summary.customer_descriptive_name = "Test Customer"
+        mock_account_budget_summary.purchase_order_number = "PO123"
+        mock_account_budget_summary.billable_activity_date_range = MagicMock()
+        mock_account_budget_summary.billable_activity_date_range.start_date = "2023-10-01"
+        mock_account_budget_summary.billable_activity_date_range.end_date = "2023-10-31"
+        mock_account_budget_summary.subtotal_amount_micros = 15000000
+        mock_account_budget_summary.tax_amount_micros = 3000000
+        mock_account_budget_summary.total_amount_micros = 18000000
+        mock_invoice.account_budget_summaries = [mock_account_budget_summary]
+
+        mock_invoice_service.list_invoices.return_value = MagicMock(invoices=[mock_invoice])
+
+        customer_id = "12345"
+        billing_setup_id = "67890"
+
+        get_invoices.main(mock_client_instance, customer_id, billing_setup_id)
+
+        last_month = date.today().replace(day=1) - timedelta(days=1)
+        expected_issue_year = str(last_month.year)
+        expected_issue_month = last_month.strftime("%B").upper()
+
+        mock_invoice_service.list_invoices.assert_called_once_with(
+            customer_id=customer_id,
+            billing_setup="customers/12345/billingSetups/67890",
+            issue_year=expected_issue_year,
+            issue_month=expected_issue_month,
+        )
+
+        output = mock_stdout.getvalue()
+        self.assertIn(f"Found the invoice {mock_invoice.resource_name}", output)
+        self.assertIn(f"ID (also known as Invoice Number): '{mock_invoice.id}'", output)
+        self.assertIn(f"subtotal {micros_to_currency_for_test(mock_invoice.adjustments_subtotal_amount_micros)}", output)
+
+        expected_replaced_invoices_str = ", ".join(mock_replaced_invoices_list) if mock_replaced_invoices_list else "none"
+        self.assertIn(f"Replaced invoices: {expected_replaced_invoices_str}", output)
+
+        self.assertIn(f"Account budget '{mock_account_budget_summary.account_budget}'", output)
+        self.assertIn(f"subtotal '{micros_to_currency_for_test(mock_account_budget_summary.subtotal_amount_micros)}'", output)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…ing` directory. Specifically, `get_invoices.py`, `add_account_budget_proposal.py`, and `add_billing_setup.py` now have corresponding tests in `examples/billing/tests/`.

These tests use `unittest.mock` to simulate interactions with the Google Ads API. This helps ensure your example scripts are making the correct service calls and handling responses as you expect.

I also confirmed that all examples in `examples/billing` already explicitly initialize the `GoogleAdsClient` with `version="v19"`.

During the development of these tests, I made minor corrections to `get_invoices.py` to fix a `NameError` and an attribute error on a mocked object.