### PR TITLE
Create Python 3.8 compatible copy of library version 28.0.0.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* 28.0.0.post1
+- Temporarily remove incompatibility with Python 3.8.
+
 * 28.0.0
 - Google Ads API v21_0 release.
 - Updated to Google Ads API v19_0 and v20_0 to include EU political advertising changes.

--- a/google/ads/googleads/__init__.py
+++ b/google/ads/googleads/__init__.py
@@ -19,12 +19,17 @@ import google.ads.googleads.client
 import google.ads.googleads.errors
 import google.ads.googleads.util
 
-VERSION = "28.0.0"
+VERSION = "28.0.0.post1"
 
-# Checks if the current runtime is Python 3.9.
-if sys.version_info.major == 3 and sys.version_info.minor <= 9:
-    warnings.warn(
-        "Support for Python versions less than 3.9 is deprecated in the "
-        "google-ads package. Please upgrade to Python 3.10 or higher.",
-        category=DeprecationWarning,
-    )
+# Warns that this version of the library is intended as a temporary workaround
+# for Python 3.8 users.
+warnings.warn(
+    "This version of google-ads-python (28.0.0.post1) is only intended for "
+    "use by Python 3.8 users who cannot upgrade to a newer version of Python "
+    "and are blocked from accessing the Google Ads API due to changes made to"
+    "comply with European Union Political Ads Regulation. For more details, "
+    "see: https://ads-developers.googleblog.com/2025/08/eu-par-google-ads-api-scripts.html. "
+    "We recommend upgrading to Python >=3.10 and google-ads-python >=28.0.0 "
+    "as soon as possible.",
+    category=Warning,
+)

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ import os
 import pathlib
 
 
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 PROTOBUF_IMPLEMENTATIONS = ["python", "upb"]
 
 TEST_COMMAND = [
@@ -39,20 +39,13 @@ COVERAGE_COMMAND = [
     "--omit=.nox/*,examples/*,*/__init__.py",
 ]
 FREEZE_COMMAND = ["python", "-m", "pip", "freeze"]
-TEST_DEPENDENCIES = [
-    "pyfakefs>=5.0.0,<6.0",
-    "coverage==6.5.0",
-]
 CURRENT_DIR = pathlib.Path(__file__).parent.absolute()
 CONSTRAINTS_DIR = os.path.join(CURRENT_DIR, "tests", "constraints")
-
 
 @nox.session(python=PYTHON_VERSIONS)
 @nox.parametrize("protobuf_implementation", PROTOBUF_IMPLEMENTATIONS)
 def tests(session, protobuf_implementation):
-    session.install("-e", ".")
-    # modules for testing
-    session.install(*TEST_DEPENDENCIES)
+    session.install("-e", ".[tests]")
     session.run(*FREEZE_COMMAND)
     session.run(
         *TEST_COMMAND,
@@ -79,8 +72,8 @@ def tests_minimum_dependency_versions(session, protobuf_implementation):
 
     constraints_file = os.path.join(CONSTRAINTS_DIR, "minimums", filename)
 
-    session.install("-e", ".")
-    session.install(*TEST_DEPENDENCIES, "-c", constraints_file)
+    session.install("-e", ".[tests]", "-c", constraints_file)
+    # session.install()
     session.run(*FREEZE_COMMAND)
     session.run(
         *TEST_COMMAND,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,21 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "google-ads"
-version = "28.0.0"
+version = "28.0.0.post1"
 description = "Client library for the Google Ads API"
 readme = "./README.rst"
-requires-python = ">=3.9, <3.14"
-license = "Apache-2.0"
+requires-python = ">=3.8, <3.14"
+license = { file = "LICENSE" }
+
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
+
 classifiers = [
-    "Intended Audience :: Developers",
-    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -59,7 +60,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = ["nox >= 2020.12.31, < 2022.6"]
+tests = [
+    "nox >= 2020.12.31, < 2022.6",
+    "pyfakefs>=5.0.0,<6.0",
+    "coverage==6.5.0",
+]
 
 [project.urls]
 Repository = "https://github.com/googleads/google-ads-python"

--- a/tests/interceptors/logging_interceptor_test.py
+++ b/tests/interceptors/logging_interceptor_test.py
@@ -305,10 +305,7 @@ class LoggingInterceptorTest(TestCase):
         )
         mock_trailing_metadata = mock_response.trailing_metadata()
 
-        with (
-            mock.patch("logging.config.dictConfig"),
-            mock.patch("google.ads.googleads.client._logger") as mock_logger,
-        ):
+        with mock.patch("logging.config.dictConfig"), mock.patch("google.ads.googleads.client._logger") as mock_logger:
             interceptor = self._create_test_interceptor(logger=mock_logger)
             interceptor.intercept_unary_unary(
                 mock_continuation_fn, mock_client_call_details, mock_request
@@ -361,10 +358,7 @@ class LoggingInterceptorTest(TestCase):
 
         mock_continuation_fn = mock.Mock(return_value=mock_response)
 
-        with (
-            mock.patch("logging.config.dictConfig"),
-            mock.patch("google.ads.googleads.client._logger") as mock_logger,
-        ):
+        with mock.patch("logging.config.dictConfig"), mock.patch("google.ads.googleads.client._logger") as mock_logger:
             interceptor = self._create_test_interceptor(logger=mock_logger)
             interceptor.intercept_unary_stream(
                 mock_continuation_fn, mock_client_call_details, mock_request
@@ -416,10 +410,7 @@ class LoggingInterceptorTest(TestCase):
         mock_continuation_fn = self._get_mock_continuation_fn(fail=True)
         mock_request = self._get_mock_request()
 
-        with (
-            mock.patch("logging.config.dictConfig"),
-            mock.patch("google.ads.googleads.client._logger") as mock_logger,
-        ):
+        with mock.patch("logging.config.dictConfig"), mock.patch("google.ads.googleads.client._logger") as mock_logger:
             interceptor = self._create_test_interceptor(logger=mock_logger)
             mock_response = interceptor.intercept_unary_unary(
                 mock_continuation_fn, mock_client_call_details, mock_request
@@ -472,10 +463,7 @@ class LoggingInterceptorTest(TestCase):
         mock_response.add_done_callback = mock_add_done_callback
         mock_continuation_fn = mock.Mock(return_value=mock_response)
 
-        with (
-            mock.patch("logging.config.dictConfig"),
-            mock.patch("google.ads.googleads.client._logger") as mock_logger,
-        ):
+        with mock.patch("logging.config.dictConfig"), mock.patch("google.ads.googleads.client._logger") as mock_logger:
             interceptor = self._create_test_interceptor(logger=mock_logger)
             mock_response = interceptor.intercept_unary_stream(
                 mock_continuation_fn, mock_client_call_details, mock_request
@@ -554,10 +542,7 @@ class LoggingInterceptorTest(TestCase):
         """Calls _format_json_object with error obj's debug_error_string."""
         interceptor = self._create_test_interceptor()
 
-        with (
-            mock.patch("logging.config.dictConfig"),
-            mock.patch.object(interceptor, "format_json_object") as mock_parser,
-        ):
+        with mock.patch("logging.config.dictConfig"), mock.patch.object(interceptor, "format_json_object") as mock_parser:
             mock_exception = self._get_mock_transport_exception()
             interceptor._parse_exception_to_str(mock_exception)
             mock_parser.assert_called_once_with(


### PR DESCRIPTION
This is a special release of the library to support Python 3.8 users who are blocked from accessing the Google Ads API due to changes made to comply with European Union Political Ads Regulation. For more details see: https://ads-developers.googleblog.com/2025/08/eu-par-google-ads-api-scripts.html

We recommend only using this as a temporary workaround until you can upgrade to Python `>=3.10`, at which point you should go back to using version `>=28.0.0` of this library.