### PR TITLE
Add check for PackageNotFoundError when initializing _CLIENT_INFO

### DIFF
--- a/google/ads/googleads/client.py
+++ b/google/ads/googleads/client.py
@@ -45,7 +45,12 @@ _DEFAULT_VERSION = _VALID_API_VERSIONS[0]
 
 # Retrieve the version of this client library to be sent in the user-agent
 # information of API calls.
-_CLIENT_INFO = ClientInfo(client_library_version=metadata.version("google-ads"))
+try:
+    _CLIENT_INFO = ClientInfo(
+        client_library_version=metadata.version("google-ads")
+    )
+except metadata.PackageNotFoundError:
+    _CLIENT_INFO = ClientInfo()
 
 # See options at grpc.github.io/grpc/core/group__grpc__arg__keys.html
 _GRPC_CHANNEL_OPTIONS = [

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -951,6 +951,16 @@ class GoogleAdsClientTest(TestCase):
                 use_cloud_org_for_api_access=None,
             )
 
+    def test_client_info_package_not_found(self):
+        with mock.patch("google.ads.googleads.client.metadata.version") as mock_version:
+            mock_version.side_effect = Client.metadata.PackageNotFoundError
+            from importlib import reload
+            reload(Client)
+            self.assertIsInstance(Client._CLIENT_INFO, Client.ClientInfo)
+            self.assertIsNone(Client._CLIENT_INFO.client_library_version)
+
+        reload(Client)
+
 
 class GoogleAdsClientTestFs(FileTestCase):
     """Tests for the GoogleAdsClient class that require a fake filesystem."""


### PR DESCRIPTION
Credit to [corlord](https://github.com/corlord) for initially proposing this change in https://github.com/googleads/google-ads-python/pull/890