### PR TITLE
Fix example to also normalize plus character in emails

### DIFF
--- a/examples/remarketing/upload_enhanced_conversions_for_leads.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_leads.py
@@ -254,14 +254,10 @@ def normalize_and_hash_email_address(email_address: str) -> str:
 
     # Check that there are at least two segments
     if len(email_parts) > 1:
-        # Checks whether the domain of the email address is either "gmail.com"
-        # or "googlemail.com". If this regex does not match then this statement
-        # will evaluate to None.
-        if re.match(r"^(gmail|googlemail)\.com$", email_parts[1]):
-            # Removes any '.' characters from the portion of the email address
-            # before the domain if the domain is gmail.com or googlemail.com.
-            email_parts[0] = email_parts[0].replace(".", "")
-            normalized_email = "@".join(email_parts)
+        # Removes any '.' and '+' characters from the portion of the email address
+        # before the domain
+        email_parts[0] = email_parts[0].replace(".", "").replace("+","")
+        normalized_email = "@".join(email_parts)
 
     return normalize_and_hash(normalized_email)
 

--- a/examples/remarketing/upload_enhanced_conversions_for_leads.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_leads.py
@@ -256,7 +256,9 @@ def normalize_and_hash_email_address(email_address: str) -> str:
     if len(email_parts) > 1:
         # Removes any '.' and '+' characters from the portion of the email address
         # before the domain
-        email_parts[0] = email_parts[0].replace(".", "").replace("+","")
+        chars_to_remove = ".+"
+        translation_table = str.maketrans('', '', chars_to_remove)
+        email_parts[0] = email_parts[0].translate(translation_table)
         normalized_email = "@".join(email_parts)
 
     return normalize_and_hash(normalized_email)

--- a/examples/remarketing/upload_enhanced_conversions_for_web.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_web.py
@@ -233,14 +233,10 @@ def normalize_and_hash_email_address(email_address):
 
     # Check that there are at least two segments
     if len(email_parts) > 1:
-        # Checks whether the domain of the email address is either "gmail.com"
-        # or "googlemail.com". If this regex does not match then this statement
-        # will evaluate to None.
-        if re.match(r"^(gmail|googlemail)\.com$", email_parts[1]):
-            # Removes any '.' characters from the portion of the email address
-            # before the domain if the domain is gmail.com or googlemail.com.
-            email_parts[0] = email_parts[0].replace(".", "")
-            normalized_email = "@".join(email_parts)
+        # Removes any '.' and '+' characters from the portion of the email address
+        # before the domain
+        email_parts[0] = email_parts[0].replace(".", "").replace("+","")
+        normalized_email = "@".join(email_parts)
 
     return normalize_and_hash(normalized_email)
 

--- a/examples/remarketing/upload_enhanced_conversions_for_web.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_web.py
@@ -235,7 +235,9 @@ def normalize_and_hash_email_address(email_address):
     if len(email_parts) > 1:
         # Removes any '.' and '+' characters from the portion of the email address
         # before the domain
-        email_parts[0] = email_parts[0].replace(".", "").replace("+","")
+        chars_to_remove = ".+"
+        translation_table = str.maketrans('', '', chars_to_remove)
+        email_parts[0] = email_parts[0].translate(translation_table)
         normalized_email = "@".join(email_parts)
 
     return normalize_and_hash(normalized_email)


### PR DESCRIPTION
Correct function to follow documentation. `+` characters also need to be removed and normalization is not only for `gmail.com` or `googlemail.com` addresses

https://developers.google.com/google-ads/api/docs/conversions/upload-offline#prepare-data
> For email addresses:
>  - Remove all periods (.) in the username (before the @ symbol). For example,   
>     jane.doe@example.com becomes janedoe@example.com.
>   - Remove the plus (+) symbol and any characters following it in the username (before the @ 
>     symbol). For example, janedoe+newsletter@example.com becomes janedoe@example.com.