### PR TITLE
fix: await response.code() and use sys.exc_info() in async gRPC interceptor

### DIFF
--- a/google/ads/googleads/interceptors/exception_interceptor.py
+++ b/google/ads/googleads/interceptors/exception_interceptor.py
@@ -26,7 +26,10 @@ import grpc
 
 from google.ads.googleads import util
 from google.ads.googleads.errors import GoogleAdsException
+import sys
+
 from google.ads.googleads.interceptors import Interceptor, ContinuationType
+from google.ads.googleads.interceptors.interceptor import _RETRY_STATUS_CODES
 from google.ads.googleads.interceptors.response_wrappers import _UnaryStreamWrapper, _UnaryUnaryWrapper
 
 
@@ -262,30 +265,17 @@ class _AsyncExceptionInterceptor(
     """An interceptor that wraps rpc exceptions."""
 
     async def _handle_grpc_failure_async(self, response: grpc.aio.Call):
-        """Async version of _handle_grpc_failure."""
-        status_code = response.code()
-        response_exception = response.exception()
+        """Async version of _handle_grpc_failure.
 
-        # We need to access _RETRY_STATUS_CODES from interceptor module?
-        # It's imported in interceptor.py but not exposed in ExceptionInterceptor?
-        # It is in interceptor.py as _RETRY_STATUS_CODES.
-        # We need to import it or access it.
-        # It is NOT imported in exception_interceptor.py?
-        # Let's check imports.
+        Note: grpc.aio.Call objects do not have a synchronous .exception()
+        method unlike sync grpc.Future objects. The active exception is
+        retrieved via sys.exc_info() since this method is always called from
+        within an except grpc.RpcError block in the async wrappers.
+        """
+        status_code = await response.code()
+        response_exception = sys.exc_info()[1]
 
-        # exception_interceptor.py imports:
-        # from google.ads.googleads.interceptors import Interceptor, ContinuationType
-
-        # _RETRY_STATUS_CODES is defined in interceptor.py but not exported in __all__?
-        # We can access it via Interceptor._RETRY_STATUS_CODES if we added it?
-        # interceptor.py has `_RETRY_STATUS_CODES` global.
-        # It is NOT in Interceptor class.
-
-        # We can import it if we modify imports or just redefine it.
-        # Redefining is safer/easier.
-        RETRY_STATUS_CODES = (grpc.StatusCode.INTERNAL, grpc.StatusCode.RESOURCE_EXHAUSTED)
-
-        if status_code not in RETRY_STATUS_CODES:
+        if status_code not in _RETRY_STATUS_CODES:
             trailing_metadata = await response.trailing_metadata()
             google_ads_failure = self._get_google_ads_failure(trailing_metadata)
 
@@ -298,9 +288,6 @@ class _AsyncExceptionInterceptor(
                 raise response_exception
         elif response_exception:
             raise response_exception
-
-        # If we got here, maybe no exception? But we only call this on error.
-        raise response.exception()
 
     async def intercept_unary_unary(
         self,


### PR DESCRIPTION
Fixes #1059

Two bugs in `_AsyncExceptionInterceptor._handle_grpc_failure_async()`:

**Bug 1: `response.exception()` raises `AttributeError`**

`grpc.aio.Call` objects don't have an `.exception()` method. That method only exists on synchronous `grpc.Future` objects. When a timeout or temporary service error triggers the async interceptor, calling `response.exception()` raises `AttributeError: 'UnaryUnaryCall' object has no attribute 'exception'`, masking the original gRPC error entirely.

Fix: use `sys.exc_info()[1]` to capture the live exception — this works since `_handle_grpc_failure_async` is always called from within an `except grpc.RpcError` block in the async wrappers.

**Bug 2: `response.code()` not awaited**

In `grpc.aio`, `Call.code()` is a coroutine and must be awaited. Without `await`, `status_code` would be a coroutine object, making the `status_code not in _RETRY_STATUS_CODES` check always evaluate to `True`, meaning retry-able errors (INTERNAL, RESOURCE_EXHAUSTED) would incorrectly be parsed as GoogleAdsFailures instead of being re-raised as-is.

**Other cleanup:**
- Removed leftover reasoning comments that were accidentally committed
- Import `_RETRY_STATUS_CODES` from `interceptor.py` instead of redefining it locally