### PR TITLE
Add logging functionality to examples

### DIFF
--- a/examples/account_management/create_customer.py
+++ b/examples/account_management/create_customer.py
@@ -21,8 +21,9 @@ account.
 """
 
 import argparse
-import sys
 from datetime import datetime
+import logging
+import sys
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -33,6 +34,9 @@ from google.ads.googleads.v24.services.services.customer_service.client import (
 from google.ads.googleads.v24.services.types.customer_service import (
     CreateCustomerClientResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START create_customer]

--- a/examples/account_management/get_account_hierarchy.py
+++ b/examples/account_management/get_account_hierarchy.py
@@ -23,6 +23,7 @@ for each accessible customer.
 """
 
 import argparse
+import logging
 import sys
 from typing import Optional, List, Dict
 
@@ -41,6 +42,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchPagedResponse,
     GoogleAdsRow,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # ListAccessibleCustomersResponse is not directly used for a variable type,
 # but its attribute .resource_names is used, which is List[str].

--- a/examples/account_management/get_change_details.py
+++ b/examples/account_management/get_change_details.py
@@ -20,6 +20,7 @@ values.
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 from typing import Any
 
@@ -37,6 +38,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     GoogleAdsRow,
 )
 from google.ads.googleads.v24.resources.types.change_event import ChangeEvent
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START get_change_details]

--- a/examples/account_management/get_change_summary.py
+++ b/examples/account_management/get_change_summary.py
@@ -17,6 +17,7 @@
 """This example gets a list of which resources have been changed in an account."""
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -30,6 +31,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     GoogleAdsRow,
 )
 from google.ads.googleads.v24.resources.types.change_status import ChangeStatus
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START get_change_summary]

--- a/examples/account_management/invite_user_with_access_role.py
+++ b/examples/account_management/invite_user_with_access_role.py
@@ -18,6 +18,7 @@ The invitation is to manage a customer account with a desired access role.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -32,6 +33,10 @@ from google.ads.googleads.v24.services.types.customer_user_access_invitation_ser
 from google.ads.googleads.v24.resources.types.customer_user_access_invitation import (
     CustomerUserAccessInvitation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # AccessRoleEnum is part of google.ads.googleads.v24.enums.types.access_role
 # but it's accessed via client.enums.AccessRoleEnum, so direct import for type hint might not be strictly needed for the parameter.

--- a/examples/account_management/link_manager_to_client.py
+++ b/examples/account_management/link_manager_to_client.py
@@ -15,6 +15,7 @@
 """This example shows how to link a manager customer to a client customer."""
 
 import argparse
+import logging
 import sys
 
 from google.api_core import protobuf_helpers
@@ -49,6 +50,10 @@ from google.ads.googleads.v24.services.types.customer_manager_link_service impor
 from google.ads.googleads.v24.resources.types.customer_manager_link import (
     CustomerManagerLink,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # ManagerLinkStatusEnum is used via client.enums
 

--- a/examples/account_management/list_accessible_customers.py
+++ b/examples/account_management/list_accessible_customers.py
@@ -20,6 +20,7 @@ the login-customer-id configuration. For more information see this
 documentation: https://developers.google.com/google-ads/api/docs/concepts/call-structure#cid
 """
 
+import logging
 import sys
 from typing import List
 
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.services.services.customer_service.client import (
 from google.ads.googleads.v24.services.types.customer_service import (
     ListAccessibleCustomersResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START list_accessible_customers]

--- a/examples/account_management/update_user_access.py
+++ b/examples/account_management/update_user_access.py
@@ -22,32 +22,13 @@ account access levels.
 """
 
 import argparse
+import logging
 import sys
-
-from google.ads.googleads.client import GoogleAdsClient
-from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v24.services.services.google_ads_service.client import (
-    GoogleAdsServiceClient,
-)
-from google.ads.googleads.v24.services.types.google_ads_service import (
-    SearchGoogleAdsRequest,
-    SearchPagedResponse,
-)
-from google.ads.googleads.v24.resources.types.customer_user_access import (
-    CustomerUserAccess,
-)
-from google.ads.googleads.v24.services.services.customer_user_access_service.client import (
-    CustomerUserAccessServiceClient,
-)
-from google.ads.googleads.v24.services.types.customer_user_access_service import (
-    CustomerUserAccessOperation,
-    MutateCustomerUserAccessResponse,
-)
-
-from google.api_core import protobuf_helpers
-from google.protobuf.field_mask_pb2 import FieldMask
-
 from typing import Optional
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 _ACCESS_ROLES = ["ADMIN", "STANDARD", "READ_ONLY", "EMAIL_ONLY"]
 

--- a/examples/account_management/verify_advertiser_identity.py
+++ b/examples/account_management/verify_advertiser_identity.py
@@ -18,6 +18,7 @@ If required and not already started, it also starts the verification process.
 """
 
 import argparse
+import logging
 import sys
 from typing import Optional
 
@@ -34,6 +35,9 @@ from google.ads.googleads.v24.services.types.identity_verification_service impor
     IdentityVerification,
     IdentityVerificationProgress,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/advanced_operations/add_ad_customizer.py
+++ b/examples/advanced_operations/add_ad_customizer.py
@@ -19,6 +19,7 @@ customizer attributes to populate dynamic data.
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -50,6 +51,9 @@ from google.ads.googleads.v24.services.types import (
     MutateAdGroupCustomizersResponse,
     MutateCustomizerAttributesResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str) -> None:

--- a/examples/advanced_operations/add_ad_group_bid_modifier.py
+++ b/examples/advanced_operations/add_ad_group_bid_modifier.py
@@ -18,6 +18,7 @@ To get ad group bid modifiers, run get_ad_group_bid_modifiers.py
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -36,6 +37,9 @@ from google.ads.googleads.v24.services.types.ad_group_bid_modifier_service impor
     AdGroupBidModifierOperation,
     MutateAdGroupBidModifiersResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_ad_group_bid_modifier]

--- a/examples/advanced_operations/add_app_campaign.py
+++ b/examples/advanced_operations/add_app_campaign.py
@@ -23,6 +23,7 @@ To upload image assets for this campaign, run misc/upload_image_asset.py.
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 from typing import List
 from uuid import uuid4
@@ -59,6 +60,9 @@ from google.ads.googleads.v24.services.services.google_ads_service import (
     GoogleAdsServiceClient,
 )
 from google.ads.googleads.v24.services.types import *
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/advanced_operations/add_bidding_data_exclusion.py
+++ b/examples/advanced_operations/add_bidding_data_exclusion.py
@@ -22,6 +22,7 @@ https://developers.google.com/google-ads/api/docs/campaigns/bidding/data-exclusi
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -37,6 +38,9 @@ from google.ads.googleads.v24.services.types.bidding_data_exclusion_service impo
     BiddingDataExclusionOperation,
     MutateBiddingDataExclusionsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/advanced_operations/add_bidding_seasonality_adjustment.py
+++ b/examples/advanced_operations/add_bidding_seasonality_adjustment.py
@@ -22,6 +22,7 @@ https://developers.google.com/google-ads/api/docs/campaigns/bidding/seasonality-
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -37,6 +38,9 @@ from google.ads.googleads.v24.services.types.bidding_seasonality_adjustment_serv
     BiddingSeasonalityAdjustmentOperation,
     MutateBiddingSeasonalityAdjustmentsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/advanced_operations/add_demand_gen_campaign.py
+++ b/examples/advanced_operations/add_demand_gen_campaign.py
@@ -18,6 +18,7 @@ https://developers.google.com/google-ads/api/docs/demand-gen/overview
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 from uuid import uuid4
@@ -50,6 +51,10 @@ from google.ads.googleads.v24.services.types import (
     CampaignOperation,
     MutateOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Temporary IDs for resources.
 BUDGET_TEMPORARY_ID: int = -1

--- a/examples/advanced_operations/add_display_upload_ad.py
+++ b/examples/advanced_operations/add_display_upload_ad.py
@@ -18,9 +18,9 @@ To get ad groups, run get_ad_groups.py.
 """
 
 import argparse
-import sys
-
+import logging
 import requests
+import sys
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -41,6 +41,10 @@ from google.ads.googleads.v24.services.types.asset_service import (
     AssetOperation,
     MutateAssetsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 BUNDLE_URL: str = "https://gaagl.page.link/ib87"
 

--- a/examples/advanced_operations/add_dynamic_page_feed_asset.py
+++ b/examples/advanced_operations/add_dynamic_page_feed_asset.py
@@ -15,6 +15,7 @@
 """Adds a page feed with URLs for a Dynamic Search Ads campaign."""
 
 import argparse
+import logging
 import sys
 from typing import List, Optional
 
@@ -74,6 +75,10 @@ from google.ads.googleads.v24.services.types.campaign_asset_set_service import (
     CampaignAssetSetOperation,
     MutateCampaignAssetSetsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # The label for the DSA page URLs.
 DSA_PAGE_URL_LABEL = "discounts"

--- a/examples/advanced_operations/add_dynamic_search_ads.py
+++ b/examples/advanced_operations/add_dynamic_search_ads.py
@@ -19,6 +19,7 @@ It also creates a webpage targeting criteria for the DSA.
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 from uuid import uuid4
 
@@ -69,6 +70,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
     MutateCampaignsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/advanced_operations/add_performance_max_campaign.py
+++ b/examples/advanced_operations/add_performance_max_campaign.py
@@ -29,6 +29,7 @@ shopping_ads/add_performance_max_retail_campaign.py
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 from typing import List, Optional, Iterable
 from uuid import uuid4
@@ -81,6 +82,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     MutateOperation,
     MutateOperationResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # We specify temporary IDs that are specific to a single mutate request.
 # Temporary IDs are always negative and unique within one mutate request.

--- a/examples/advanced_operations/add_responsive_search_ad_full.py
+++ b/examples/advanced_operations/add_responsive_search_ad_full.py
@@ -23,9 +23,10 @@ https://support.google.com/google-ads/answer/7684791
 """
 
 import argparse
+import logging
 import sys
-import uuid
 from typing import List, Optional
+import uuid
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -114,6 +115,10 @@ from google.ads.googleads.v24.services.types.customizer_attribute_service import
     CustomizerAttributeOperation,
     MutateCustomizerAttributesResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Keywords from user.
 KEYWORD_TEXT_EXACT = "example of exact match"

--- a/examples/advanced_operations/add_smart_campaign.py
+++ b/examples/advanced_operations/add_smart_campaign.py
@@ -19,6 +19,7 @@ https://support.google.com/google-ads/answer/7652860
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Optional
 from uuid import uuid4
@@ -101,6 +102,10 @@ from google.ads.googleads.v24.services.types.smart_campaign_setting_service impo
     SmartCampaignSettingOperation,
 )
 from google.api_core import protobuf_helpers
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Geo target constant for New York City.
 _GEO_TARGET_CONSTANT = "1023191"

--- a/examples/advanced_operations/create_and_attach_shared_keyword_set.py
+++ b/examples/advanced_operations/create_and_attach_shared_keyword_set.py
@@ -18,6 +18,7 @@ Note that the keywords will be attached to the specified campaign.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 import uuid
@@ -57,6 +58,9 @@ from google.ads.googleads.v24.services.types.shared_set_service import (
     MutateSharedSetsResponse,
     SharedSetOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/advanced_operations/find_and_remove_criteria_from_shared_set.py
+++ b/examples/advanced_operations/find_and_remove_criteria_from_shared_set.py
@@ -15,6 +15,7 @@
 """Demonstrates how to find and remove shared sets, and shared set criteria."""
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -45,6 +46,9 @@ from google.ads.googleads.v24.services.types.shared_criterion_service import (
     MutateSharedCriterionResult,
     SharedCriterionOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/advanced_operations/get_ad_group_bid_modifiers.py
+++ b/examples/advanced_operations/get_ad_group_bid_modifiers.py
@@ -15,6 +15,7 @@
 """This example illustrates how to retrieve ad group bid modifiers."""
 
 import argparse
+import logging
 import sys
 from typing import Optional
 
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsRequest,
     SearchGoogleAdsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/advanced_operations/upload_video.py
+++ b/examples/advanced_operations/upload_video.py
@@ -16,9 +16,9 @@
 
 import argparse
 import itertools
+import logging
 import os
 import sys
-import logging
 from typing import Iterator, Iterable, List, MutableSequence
 
 import google.auth
@@ -50,6 +50,9 @@ from google.ads.googleads.v24.services.types.youtube_video_upload_service import
 
 from google.protobuf import field_mask_pb2
 from google.ads.googleads.v24.resources.types import youtube_video_upload
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/advanced_operations/use_cross_account_bidding_strategy.py
+++ b/examples/advanced_operations/use_cross_account_bidding_strategy.py
@@ -19,6 +19,7 @@ all manager-owned and customer accessible bidding strategies.
 """
 
 import argparse
+import logging
 import sys
 from typing import Iterator
 from uuid import uuid4
@@ -56,6 +57,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     GoogleAdsRow,
     SearchGoogleAdsStreamResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/advanced_operations/use_portfolio_bidding_strategy.py
+++ b/examples/advanced_operations/use_portfolio_bidding_strategy.py
@@ -15,6 +15,7 @@
 """This example constructs a campaign with a Portfolio Bidding Strategy."""
 
 import argparse
+import logging
 import sys
 import uuid
 
@@ -49,6 +50,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
     MutateCampaignsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/assets/add_call.py
+++ b/examples/assets/add_call.py
@@ -15,8 +15,9 @@
 """This example adds a call asset to a specific account."""
 
 import argparse
-from typing import Optional
+import logging
 import sys
+from typing import Optional
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -29,6 +30,10 @@ from google.ads.googleads.v24.services.types.customer_asset_service import (
 from google.ads.googleads.v24.resources.types.customer_asset import (
     CustomerAsset,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Country code is a two-letter ISO-3166 code, for a list of all codes see:
 # https://developers.google.com/google-ads/api/reference/data/codes-formats#expandable-17

--- a/examples/assets/add_hotel_callout.py
+++ b/examples/assets/add_hotel_callout.py
@@ -15,8 +15,9 @@
 """This example adds a hotel callout extension asset to a specific account."""
 
 import argparse
-from typing import List
+import logging
 import sys
+from typing import List
 
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -29,6 +30,9 @@ from google.ads.googleads.v24.services.types.customer_asset_service import (
 from google.ads.googleads.v24.resources.types.customer_asset import (
     CustomerAsset,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, language_code: str) -> None:

--- a/examples/assets/add_lead_form_asset.py
+++ b/examples/assets/add_lead_form_asset.py
@@ -18,6 +18,7 @@ Run add_campaigns.py to create a campaign.
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -36,6 +37,9 @@ from google.ads.googleads.v24.services.types.campaign_asset_service import (
 from google.ads.googleads.v24.resources.types.campaign_asset import (
     CampaignAsset,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/assets/add_prices.py
+++ b/examples/assets/add_prices.py
@@ -15,8 +15,9 @@
 """This example adds a price asset and associates it with an account."""
 
 import argparse
-from typing import Optional
+import logging
 import sys
+from typing import Optional
 from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -34,6 +35,9 @@ from google.ads.googleads.v24.services.types.customer_asset_service import (
 from google.ads.googleads.v24.resources.types.customer_asset import (
     CustomerAsset,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/assets/add_sitelinks.py
+++ b/examples/assets/add_sitelinks.py
@@ -18,8 +18,9 @@ Run basic_operations/add_campaigns.py to create a campaign.
 """
 
 import argparse
-from typing import List
+import logging
 import sys
+from typing import List
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.services.types.campaign_asset_service import (
 from google.ads.googleads.v24.resources.types.campaign_asset import (
     CampaignAsset,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/assets/upload_image_asset.py
+++ b/examples/assets/upload_image_asset.py
@@ -18,6 +18,7 @@ To get image assets, run get_all_image_assets.py.
 """
 
 import argparse
+import logging
 import sys
 
 from examples.utils.example_helpers import get_image_bytes_from_url
@@ -25,6 +26,9 @@ from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
 from google.ads.googleads.v24.services.types.asset_service import AssetOperation
 from google.ads.googleads.v24.resources.types.asset import Asset
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START upload_image_asset]

--- a/examples/asyncio/async_add_campaigns.py
+++ b/examples/asyncio/async_add_campaigns.py
@@ -15,8 +15,8 @@
 """This example illustrates how to add a campaign using asyncio."""
 
 import argparse
-import asyncio
 import datetime
+import logging
 import sys
 from typing import List
 import uuid
@@ -37,6 +37,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     MutateGoogleAdsResponse,
     MutateOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 _START_DATE_FORMAT: str = "%Y%m%d 00:00:00"
 _END_DATE_FORMAT: str = "%Y%m%d 23:59:59"

--- a/examples/asyncio/async_search.py
+++ b/examples/asyncio/async_search.py
@@ -15,7 +15,7 @@
 """This example illustrates how to get all campaigns using asyncio."""
 
 import argparse
-import asyncio
+import logging
 import sys
 from typing import List
 
@@ -27,6 +27,9 @@ from google.ads.googleads.v24.services.services.google_ads_service import (
 from google.ads.googleads.v24.services.types.google_ads_service import (
     GoogleAdsRow,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 async def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/asyncio/async_search_stream.py
+++ b/examples/asyncio/async_search_stream.py
@@ -15,7 +15,7 @@
 """This example illustrates how to get all campaigns using asyncio."""
 
 import argparse
-import asyncio
+import logging
 import sys
 from typing import List
 
@@ -27,6 +27,9 @@ from google.ads.googleads.v24.services.services.google_ads_service import (
 from google.ads.googleads.v24.services.types.google_ads_service import (
     GoogleAdsRow,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 async def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/audience_insights/generate_audience_insights.py
+++ b/examples/audience_insights/generate_audience_insights.py
@@ -15,6 +15,7 @@
 """This example illustrates how to generate audience insights."""
 
 import argparse
+import logging
 import sys
 from typing import Any
 
@@ -42,6 +43,9 @@ from google.ads.googleads.v24.common.types import (
     AudienceInsightsAttribute,
     LocationInfo,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, custom_name: str) -> None:

--- a/examples/basic_operations/add_ad_groups.py
+++ b/examples/basic_operations/add_ad_groups.py
@@ -18,6 +18,7 @@ To get ad groups, run get_ad_groups.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 import uuid
@@ -35,6 +36,9 @@ from google.ads.googleads.v24.services.services.campaign_service import (
     CampaignServiceClient,
 )
 from google.ads.googleads.v24.resources.types.ad_group import AdGroup
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/basic_operations/add_campaigns.py
+++ b/examples/basic_operations/add_campaigns.py
@@ -19,6 +19,7 @@ To get campaigns, run get_campaigns.py.
 
 import argparse
 import datetime
+import logging
 import sys
 from typing import List
 import uuid
@@ -43,6 +44,10 @@ from google.ads.googleads.v24.resources.types.campaign_budget import (
     CampaignBudget,
 )
 from google.ads.googleads.v24.resources.types.campaign import Campaign
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 _START_DATE_FORMAT: str = "%Y%m%d 00:00:00"
 _END_DATE_FORMAT: str = "%Y%m%d 23:59:59"

--- a/examples/basic_operations/get_campaigns.py
+++ b/examples/basic_operations/get_campaigns.py
@@ -18,6 +18,7 @@ To add campaigns, run add_campaigns.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import Iterator, List
 
@@ -30,6 +31,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsStreamResponse,
     GoogleAdsRow,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START get_campaigns]

--- a/examples/basic_operations/get_responsive_search_ads.py
+++ b/examples/basic_operations/get_responsive_search_ads.py
@@ -19,6 +19,7 @@ To get ad groups, run basic_operations/get_ad_groups.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Optional, Sequence
 
@@ -33,6 +34,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsRequest,
     SearchGoogleAdsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/basic_operations/pause_ad.py
+++ b/examples/basic_operations/pause_ad.py
@@ -15,6 +15,7 @@
 """This example pauses an ad."""
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -30,6 +31,9 @@ from google.ads.googleads.v24.services.types.ad_group_ad_service import (
     AdGroupAdOperation,
     MutateAdGroupAdsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/basic_operations/remove_campaign.py
+++ b/examples/basic_operations/remove_campaign.py
@@ -15,6 +15,7 @@
 """This example removes an existing campaign."""
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -27,6 +28,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
     MutateCampaignsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/basic_operations/search_for_google_ads_fields.py
+++ b/examples/basic_operations/search_for_google_ads_fields.py
@@ -21,6 +21,7 @@ campaign) or a field (such as metrics.impressions, campaign.id).
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -35,6 +36,9 @@ from google.ads.googleads.v24.services.types.google_ads_field_service import (
     SearchGoogleAdsFieldsRequest,
     SearchGoogleAdsFieldsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, name_prefix: str) -> None:

--- a/examples/basic_operations/update_ad_group.py
+++ b/examples/basic_operations/update_ad_group.py
@@ -18,6 +18,7 @@ To get ad groups, run get_ad_groups.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -36,6 +37,9 @@ from google.ads.googleads.v24.services.types.ad_group_service import (
     AdGroupOperation,
     MutateAdGroupsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START update_ad_group]

--- a/examples/basic_operations/update_campaign.py
+++ b/examples/basic_operations/update_campaign.py
@@ -18,6 +18,7 @@ To get campaigns, run get_campaigns.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -33,6 +34,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
     MutateCampaignsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/basic_operations/update_responsive_search_ad.py
+++ b/examples/basic_operations/update_responsive_search_ad.py
@@ -18,6 +18,7 @@ To get responsive search ads, run get_responsive_search_ads.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 from uuid import uuid4
@@ -35,6 +36,9 @@ from google.ads.googleads.v24.services.types.ad_service import (
     AdOperation,
     MutateAdsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START update_responsive_search_ad]

--- a/examples/billing/add_account_budget_proposal.py
+++ b/examples/billing/add_account_budget_proposal.py
@@ -18,11 +18,15 @@ To get account budget proposal, run get_account_budget_proposals.py
 """
 
 import argparse
+import logging
 import sys
 
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_account_budget_proposal]

--- a/examples/billing/add_billing_setup.py
+++ b/examples/billing/add_billing_setup.py
@@ -25,12 +25,16 @@ manager account and is linked to a customer account via a billing setup.
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 from typing import Any, Optional
 from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/billing/get_invoices.py
+++ b/examples/billing/get_invoices.py
@@ -16,11 +16,15 @@
 
 import argparse
 from datetime import date, timedelta
+import logging
 import sys
 from typing import Optional
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, billing_setup_id: str):

--- a/examples/campaign_management/add_campaign_labels.py
+++ b/examples/campaign_management/add_campaign_labels.py
@@ -18,6 +18,7 @@ This example assumes that a label has already been prepared.
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Any
 
@@ -38,6 +39,9 @@ from google.ads.googleads.v24.services.types.campaign_label_service import (
 from google.ads.googleads.v24.resources.types.campaign_label import (
     CampaignLabel,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_campaign_labels]

--- a/examples/campaign_management/add_complete_campaigns_using_batch_job.py
+++ b/examples/campaign_management/add_complete_campaigns_using_batch_job.py
@@ -18,10 +18,10 @@ Complete campaigns include campaign budgets, campaigns, ad groups and keywords.
 """
 
 import argparse
-import asyncio
+import logging
 import sys
-from uuid import uuid4
 from typing import Any, List, Coroutine
+from uuid import uuid4
 
 from google.api_core.operation import Operation
 
@@ -61,6 +61,10 @@ from google.ads.googleads.v24.services.types.ad_group_ad_service import (
 from google.ads.googleads.v24.services.types.batch_job_service import (
     BatchJobOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 NUMBER_OF_CAMPAIGNS_TO_ADD: int = 2
 NUMBER_OF_AD_GROUPS_TO_ADD: int = 2

--- a/examples/campaign_management/get_all_disapproved_ads.py
+++ b/examples/campaign_management/get_all_disapproved_ads.py
@@ -15,6 +15,7 @@
 """This illustrates how to retrieve disapproved ads in a given campaign."""
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.resources.types.ad import Ad
 from google.ads.googleads.v24.enums.types.policy_approval_status import (
     PolicyApprovalStatusEnum,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/campaign_management/set_ad_parameters.py
+++ b/examples/campaign_management/set_ad_parameters.py
@@ -15,6 +15,7 @@
 """This example sets ad parameters for an ad group criterion."""
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.services.types.ad_parameter_service import (
     MutateAdParametersResponse,
 )
 from google.ads.googleads.v24.resources.types.ad_parameter import AdParameter
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/campaign_management/update_campaign_criterion_bid_modifier.py
+++ b/examples/campaign_management/update_campaign_criterion_bid_modifier.py
@@ -15,6 +15,7 @@
 """Updates a campaign criterion with a new bid modifier."""
 
 import argparse
+import logging
 import sys
 
 from google.api_core import protobuf_helpers
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.services.types.campaign_criterion_service import (
 from google.ads.googleads.v24.resources.types.campaign_criterion import (
     CampaignCriterion,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/campaign_management/validate_ad.py
+++ b/examples/campaign_management/validate_ad.py
@@ -20,6 +20,7 @@ will still be thrown.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -41,6 +42,9 @@ from google.ads.googleads.v24.errors.types.policy_finding_error import (
     PolicyFindingErrorEnum,
 )
 from google.ads.googleads.v24.common.types.policy import PolicyTopicEntry
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str) -> None:

--- a/examples/custom_logging_interceptor/cloud_logging_interceptor.py
+++ b/examples/custom_logging_interceptor/cloud_logging_interceptor.py
@@ -19,6 +19,8 @@ human readable structure and logs them using the logging service instantiated
 within the class (in this case, a Cloud Logging client).
 """
 
+import logging
+import sys
 import time
 from typing import Any, Callable, Dict, Optional
 
@@ -26,6 +28,9 @@ from google.cloud import logging as google_cloud_logging
 from grpc._interceptor import _ClientCallDetails
 
 from google.ads.googleads.interceptors import LoggingInterceptor
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 class CloudLoggingInterceptor(LoggingInterceptor):

--- a/examples/custom_logging_interceptor/get_campaigns.py
+++ b/examples/custom_logging_interceptor/get_campaigns.py
@@ -18,6 +18,7 @@ Google Cloud Logging using a custom logging interceptor.
 """
 
 import argparse
+import logging
 import sys
 from typing import Any, Iterable
 
@@ -34,6 +35,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
 )
 
 from cloud_logging_interceptor import CloudLoggingInterceptor
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/error_handling/handle_keyword_policy_violations.py
+++ b/examples/error_handling/handle_keyword_policy_violations.py
@@ -26,6 +26,7 @@ non-violating keyword.
 """
 
 import argparse
+import logging
 import sys
 from typing import Any, List, Optional, Tuple
 
@@ -38,6 +39,9 @@ from google.ads.googleads.v24.services.types.ad_group_criterion_service import (
     AdGroupCriterionOperation,
 )
 from google.ads.googleads.v24.common.types.policy import PolicyViolationKey
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/error_handling/handle_partial_failure.py
+++ b/examples/error_handling/handle_partial_failure.py
@@ -15,9 +15,10 @@
 """This shows how to handle responses that may include partial_failure errors."""
 
 import argparse
+import logging
 import sys
-import uuid
 from typing import Any, List
+import uuid
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -32,6 +33,9 @@ from google.ads.googleads.v24.services.types.ad_group_service import (
     MutateAdGroupsResponse,
     MutateAdGroupsRequest,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/error_handling/handle_rate_exceeded_error.py
+++ b/examples/error_handling/handle_rate_exceeded_error.py
@@ -23,6 +23,8 @@ application.
 """
 
 import argparse
+import logging
+import sys
 from time import sleep
 from typing import List, Any
 
@@ -40,6 +42,10 @@ from google.ads.googleads.v24.services.types.ad_group_criterion_service import (
     MutateAdGroupCriteriaRequest,
     MutateAdGroupCriteriaResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Number of requests to be run.
 NUM_REQUESTS: int = 5

--- a/examples/error_handling/handle_responsive_search_ad_policy_violations.py
+++ b/examples/error_handling/handle_responsive_search_ad_policy_violations.py
@@ -19,9 +19,10 @@ errors, the example will stop instead of trying sending an exemption request.
 """
 
 import argparse
+import logging
 import sys
-import uuid
 from typing import List
+import uuid
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -45,6 +46,9 @@ from google.ads.googleads.v24.common.types.ad_asset import (
 from google.ads.googleads.v24.errors.types.policy_finding_error import (
     PolicyFindingErrorEnum,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str) -> None:

--- a/examples/experiments/create_asset_optimization_experiment.py
+++ b/examples/experiments/create_asset_optimization_experiment.py
@@ -18,6 +18,7 @@ within Performance Max campaigns.
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Tuple, Any
 from uuid import uuid4
@@ -28,6 +29,9 @@ from google.ads.googleads.errors import GoogleAdsException
 from google.ads.googleads.v24.services.types.google_ads_service import (
     MutateOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/experiments/create_search_adopt_ai_max_experiment.py
+++ b/examples/experiments/create_search_adopt_ai_max_experiment.py
@@ -18,6 +18,7 @@ the feature (in this case, AI Max) is enabled or not.
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -25,6 +26,9 @@ from google.api_core import protobuf_helpers
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/experiments/create_search_custom_experiment.py
+++ b/examples/experiments/create_search_custom_experiment.py
@@ -25,9 +25,10 @@ intra-campaign or asset optimization experiments.
 """
 
 import argparse
+import logging
 import sys
-import uuid
 from typing import List, Any
+import uuid
 
 from google.api_core import protobuf_helpers
 
@@ -59,6 +60,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
 )
 from google.ads.googleads.v24.resources.types.campaign import Campaign
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/experiments/evaluate_and_update_experiment.py
+++ b/examples/experiments/evaluate_and_update_experiment.py
@@ -20,6 +20,7 @@ and how to execute actions such as promoting, ending, or graduating an experimen
 """
 
 import argparse
+import logging
 import sys
 import uuid
 
@@ -42,6 +43,10 @@ from google.ads.googleads.v24.services.services.campaign_budget_service import (
 from google.ads.googleads.v24.services.types.experiment_service import (
     CampaignBudgetMapping,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Constants for decision making
 # Choose a confidence level based on your specific needs.

--- a/examples/google-ads-account-analyzer-demo/analyzer.py
+++ b/examples/google-ads-account-analyzer-demo/analyzer.py
@@ -16,11 +16,16 @@
 
 
 import argparse
+import logging
 import sys
 from typing import Optional, Dict, List, Any
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 _DEFAULT_LOG_SPACE_LENGTH = 4
 

--- a/examples/incentives/apply_incentive.py
+++ b/examples/incentives/apply_incentive.py
@@ -21,6 +21,7 @@ fetch_incentives.py example to get the available incentives.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -32,6 +33,9 @@ from google.ads.googleads.v24.services import (
 from google.ads.googleads.v24.services.services.incentive_service.client import (
     IncentiveServiceClient,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/incentives/fetch_incentives.py
+++ b/examples/incentives/fetch_incentives.py
@@ -18,6 +18,7 @@ To apply an incentive, use apply_incentive.py.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -29,6 +30,9 @@ from google.ads.googleads.v24.services import (
 from google.ads.googleads.v24.services.services.incentive_service.client import (
     IncentiveServiceClient,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/misc/add_ad_group_image_asset.py
+++ b/examples/misc/add_ad_group_image_asset.py
@@ -18,6 +18,7 @@ To upload image assets, run misc/upload_image_asset.py.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -31,6 +32,9 @@ from google.ads.googleads.v24.services.types.ad_group_asset_service import (
     MutateAdGroupAssetResult,
     MutateAdGroupAssetsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/misc/campaign_report_to_csv.py
+++ b/examples/misc/campaign_report_to_csv.py
@@ -28,6 +28,7 @@ Examples:
 """
 
 import argparse
+import csv
 import logging
 import os
 import sys

--- a/examples/misc/campaign_report_to_csv.py
+++ b/examples/misc/campaign_report_to_csv.py
@@ -28,8 +28,7 @@ Examples:
 """
 
 import argparse
-import csv
-from collections.abc import Iterator
+import logging
 import os
 import sys
 
@@ -43,6 +42,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsStreamRequest,
     SearchGoogleAdsStreamResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 _DEFAULT_FILE_NAME = "campaign_report_to_csv_results.csv"
 _QUERY: str = """

--- a/examples/misc/set_custom_client_timeouts.py
+++ b/examples/misc/set_custom_client_timeouts.py
@@ -23,7 +23,7 @@ https://grpc.io/docs/what-is-grpc/core-concepts/#rpc-life-cycle
 """
 
 import argparse
-from collections.abc import Iterator
+import logging
 import sys
 from typing import List
 
@@ -40,6 +40,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
 )
 from google.api_core.exceptions import DeadlineExceeded
 from google.api_core.retry import Retry
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 _CLIENT_TIMEOUT_SECONDS = 5 * 60  # 5 minutes.
 _QUERY: str = "SELECT campaign.id FROM campaign"

--- a/examples/misc/upload_image_asset.py
+++ b/examples/misc/upload_image_asset.py
@@ -18,6 +18,7 @@ To get image assets, run get_all_image_assets.py.
 """
 
 import argparse
+import logging
 import sys
 
 from examples.utils.example_helpers import get_image_bytes_from_url
@@ -32,6 +33,9 @@ from google.ads.googleads.v24.services.types.asset_service import (
     MutateAssetResult,
     MutateAssetsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START upload_image_asset]

--- a/examples/planning/forecast_reach.py
+++ b/examples/planning/forecast_reach.py
@@ -15,6 +15,7 @@
 """This code example generates a video ads reach forecast."""
 
 import argparse
+import logging
 import math
 import sys
 
@@ -43,6 +44,10 @@ from google.ads.googleads.v24.services.types.reach_plan_service import (
     PlannedProductReachForecast,
     PlannedProduct,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 ONE_MILLION = 1.0e6
 

--- a/examples/planning/generate_forecast_metrics.py
+++ b/examples/planning/generate_forecast_metrics.py
@@ -20,6 +20,7 @@ https://developers.google.com/google-ads/api/docs/keyword-planning/generate-fore
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -39,6 +40,9 @@ from google.ads.googleads.v24.services.types.keyword_plan_idea_service import (
     GenerateKeywordForecastMetricsRequest,
     GenerateKeywordForecastMetricsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START generate_forecast_metrics]

--- a/examples/planning/generate_historical_metrics.py
+++ b/examples/planning/generate_historical_metrics.py
@@ -18,9 +18,10 @@ For more details see this guide:
 https://developers.google.com/google-ads/api/docs/keyword-planning/generate-historical-metrics
 """
 
-from typing import Iterable
 import argparse
+import logging
 import sys
+from typing import Iterable
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -39,6 +40,9 @@ from google.ads.googleads.v24.services.types.keyword_plan_idea_service import (
     GenerateKeywordHistoricalMetricsResponse,
     GenerateKeywordHistoricalMetricsResult,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START generate_historical_metrics]

--- a/examples/planning/generate_keyword_ideas.py
+++ b/examples/planning/generate_keyword_ideas.py
@@ -15,6 +15,7 @@
 """This example generates keyword ideas from a list of seed keywords."""
 
 import argparse
+import logging
 import sys
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -37,6 +38,10 @@ from google.ads.googleads.v24.services.types.keyword_plan_idea_service import (
     GenerateKeywordIdeasRequest,
     GenerateKeywordIdeaResult,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Location IDs are listed here:
 # https://developers.google.com/google-ads/api/reference/data/geotargets

--- a/examples/planning/get_ad_group_criterion_cpc_bid_simulations.py
+++ b/examples/planning/get_ad_group_criterion_cpc_bid_simulations.py
@@ -17,9 +17,10 @@
 To get ad groups, run get_ad_groups.py.
 """
 
-from typing import Iterable
 import argparse
+import logging
 import sys
+from typing import Iterable
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -36,6 +37,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsStreamResponse,
     GoogleAdsRow,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START get_ad_group_criterion_cpc_bid_simulations]

--- a/examples/recommendations/detect_and_apply_recommendations.py
+++ b/examples/recommendations/detect_and_apply_recommendations.py
@@ -29,6 +29,7 @@ https://developers.google.com/google-ads/api/docs/recommendations#recommendation
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Iterable
 
@@ -41,6 +42,9 @@ from google.ads.googleads.v24.services.types.recommendation_service import (
     ApplyRecommendationOperation,
     ApplyRecommendationResult,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/recommendations/dismiss_recommendation.py
+++ b/examples/recommendations/dismiss_recommendation.py
@@ -18,6 +18,7 @@ To retrieve recommendations for text ads, run get_text_ad_recommendations.py.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -29,6 +30,9 @@ from google.ads.googleads.v24.services.types.recommendation_service import (
     DismissRecommendationRequest,
     DismissRecommendationResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/recommendations/generate_budget_recommendations.py
+++ b/examples/recommendations/generate_budget_recommendations.py
@@ -25,6 +25,7 @@ To get impact metrics for a custom budget, run get_recommendation_impact_metrics
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Dict, Any
 
@@ -40,6 +41,9 @@ from google.ads.googleads.v24.services.types.recommendation_service import (
 from google.ads.googleads.v24.resources.types.recommendation import (
     Recommendation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/recommendations/get_recommendation_impact_metrics.py
+++ b/examples/recommendations/get_recommendation_impact_metrics.py
@@ -25,6 +25,7 @@ To get budget recommendations, run generate_budget_recommendations.py.
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Dict, Any
 
@@ -40,6 +41,9 @@ from google.ads.googleads.v24.services.types.recommendation_service import (
 from google.ads.googleads.v24.resources.types.recommendation import (
     Recommendation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/remarketing/add_conversion_action.py
+++ b/examples/remarketing/add_conversion_action.py
@@ -15,6 +15,7 @@
 """This example illustrates adding a conversion action."""
 
 import argparse
+import logging
 import sys
 import uuid
 
@@ -30,6 +31,9 @@ from google.ads.googleads.v24.services.types.conversion_action_service import (
     ConversionActionOperation,
     MutateConversionActionsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_conversion_action]

--- a/examples/remarketing/add_conversion_based_user_list.py
+++ b/examples/remarketing/add_conversion_based_user_list.py
@@ -20,9 +20,10 @@ e.g. by visiting a site and making a purchase.
 """
 
 import argparse
+import logging
 import sys
-from uuid import uuid4
 from typing import List
+from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -38,6 +39,9 @@ from google.ads.googleads.v24.services.types.user_list_service import (
     UserListOperation,
     MutateUserListsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_conversion_based_user_list]

--- a/examples/remarketing/add_custom_audience.py
+++ b/examples/remarketing/add_custom_audience.py
@@ -20,6 +20,7 @@ https://support.google.com/google-ads/answer/9805516
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -39,6 +40,9 @@ from google.ads.googleads.v24.services.types.custom_audience_service import (
 from google.ads.googleads.v24.services.services.custom_audience_service import (
     CustomAudienceServiceClient,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/remarketing/add_customer_match_user_list.py
+++ b/examples/remarketing/add_customer_match_user_list.py
@@ -28,9 +28,10 @@ at: https://support.google.com/adspolicy/answer/6299717.
 
 import argparse
 import hashlib
+import logging
 import sys
-import uuid
 from typing import List, Dict, Optional, Union, Iterable
+import uuid
 
 from google.protobuf.any_pb2 import Any
 from google.rpc import status_pb2
@@ -74,6 +75,9 @@ from google.ads.googleads.v24.errors.types.errors import (
     GoogleAdsFailure,
     GoogleAdsError,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/remarketing/add_dynamic_remarketing_asset.py
+++ b/examples/remarketing/add_dynamic_remarketing_asset.py
@@ -16,6 +16,7 @@
 
 import argparse
 from datetime import datetime
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -62,6 +63,9 @@ from google.ads.googleads.v24.services.types.campaign_asset_set_service import (
 from google.ads.googleads.v24.services.services.google_ads_service import (
     GoogleAdsServiceClient,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/remarketing/add_flexible_rule_user_list.py
+++ b/examples/remarketing/add_flexible_rule_user_list.py
@@ -19,6 +19,7 @@ two different pages of a website.
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -40,6 +41,9 @@ from google.ads.googleads.v24.services.types.user_list_service import (
     UserListOperation,
     MutateUserListsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_combined_rule_user_list]

--- a/examples/remarketing/add_logical_user_list.py
+++ b/examples/remarketing/add_logical_user_list.py
@@ -19,9 +19,10 @@ lists.
 """
 
 import argparse
+import logging
 import sys
-from uuid import uuid4
 from typing import List
+from uuid import uuid4
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -37,6 +38,9 @@ from google.ads.googleads.v24.services.types.user_list_service import (
     UserListOperation,
     MutateUserListsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_logical_user_list]

--- a/examples/remarketing/add_merchant_center_dynamic_remarketing_campaign.py
+++ b/examples/remarketing/add_merchant_center_dynamic_remarketing_campaign.py
@@ -19,6 +19,7 @@ targets a user list for remarketing purposes.
 """
 
 import argparse
+import logging
 import requests
 import sys
 from uuid import uuid4
@@ -74,6 +75,9 @@ from google.ads.googleads.v24.common.types.ad_asset import (
 from google.ads.googleads.v24.common.types.ad_type_infos import (
     ResponsiveDisplayAdInfo,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/remarketing/set_up_advanced_remarketing.py
+++ b/examples/remarketing/set_up_advanced_remarketing.py
@@ -20,6 +20,7 @@ more than one item in their cart.
 """
 
 import argparse
+import logging
 import sys
 from uuid import uuid4
 
@@ -46,6 +47,9 @@ from google.ads.googleads.v24.services.types.user_list_service import (
     MutateUserListsResponse,
     UserListOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/remarketing/set_up_remarketing.py
+++ b/examples/remarketing/set_up_remarketing.py
@@ -25,6 +25,7 @@ purposes.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 from uuid import uuid4
@@ -75,6 +76,9 @@ from google.ads.googleads.v24.services.types.user_list_service import (
     MutateUserListsResponse,
     UserListOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/remarketing/update_audience_target_restriction.py
+++ b/examples/remarketing/update_audience_target_restriction.py
@@ -15,6 +15,7 @@
 """Updates the audience target restriction of a given ad group to bid only."""
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -41,6 +42,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsResponse,
 )
 from google.api_core import protobuf_helpers
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str) -> None:

--- a/examples/remarketing/upload_call_conversion.py
+++ b/examples/remarketing/upload_call_conversion.py
@@ -18,6 +18,7 @@ To set up a conversion action, run the add_conversion_action.py example.
 """
 
 import argparse
+import logging
 import sys
 from typing import Optional
 
@@ -36,6 +37,9 @@ from google.ads.googleads.v24.services.types.conversion_upload_service import (
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START upload_call_conversion]

--- a/examples/remarketing/upload_conversion_adjustment.py
+++ b/examples/remarketing/upload_conversion_adjustment.py
@@ -18,6 +18,7 @@ To set up a conversion action, run the add_conversion_action.py example.
 """
 
 import argparse
+import logging
 import sys
 from typing import Optional, Iterable
 
@@ -44,6 +45,9 @@ from google.ads.googleads.v24.services.types.conversion_adjustment_upload_servic
     UploadConversionAdjustmentsRequest,
     UploadConversionAdjustmentsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START upload_conversion_adjustment]

--- a/examples/remarketing/upload_enhanced_conversions_for_leads.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_leads.py
@@ -22,6 +22,7 @@ that drove the lead.
 
 import argparse
 import hashlib
+import logging
 import re
 import sys
 from typing import Dict, Optional, Union
@@ -43,6 +44,9 @@ from google.ads.googleads.v24.services.types.conversion_upload_service import (
     SessionAttributeKeyValuePair,
     UploadClickConversionsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/remarketing/upload_enhanced_conversions_for_web.py
+++ b/examples/remarketing/upload_enhanced_conversions_for_web.py
@@ -19,11 +19,15 @@ The conversion adjustment contains hashed user identifiers and an order ID.
 
 import argparse
 import hashlib
+import logging
 import re
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/remarketing/upload_offline_conversion.py
+++ b/examples/remarketing/upload_offline_conversion.py
@@ -20,6 +20,7 @@ To set up a conversion action, run the add_conversion_action.py example.
 """
 
 import argparse
+import logging
 import sys
 from typing import Optional
 
@@ -38,6 +39,9 @@ from google.ads.googleads.v24.services.types.conversion_upload_service import (
     UploadClickConversionsRequest,
     UploadClickConversionsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START upload_offline_conversion]

--- a/examples/remarketing/upload_store_sales_transactions.py
+++ b/examples/remarketing/upload_store_sales_transactions.py
@@ -21,6 +21,7 @@ See https://support.google.com/google-ads/answer/7620302 for more details.
 import argparse
 from datetime import datetime
 import hashlib
+import logging
 import sys
 from typing import List, Optional, Tuple
 
@@ -64,6 +65,9 @@ from google.ads.googleads.v24.services.types.offline_user_data_job_service impor
     CreateOfflineUserDataJobResponse,
     OfflineUserDataJobOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/reporting/parallel_report_download.py
+++ b/examples/reporting/parallel_report_download.py
@@ -21,7 +21,9 @@ account_management/list_accessible_customers.py examples.
 
 import argparse
 from itertools import product
+import logging
 import multiprocessing
+import sys
 import time
 from typing import Any, Dict, Iterable, List, Tuple
 
@@ -38,6 +40,10 @@ from google.ads.googleads.v24.services.types import (
     GoogleAdsRow,
     SearchGoogleAdsStreamResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Maximum number of processes to spawn.
 MAX_PROCESSES: int = multiprocessing.cpu_count()

--- a/examples/shopping_ads/add_listing_scope.py
+++ b/examples/shopping_ads/add_listing_scope.py
@@ -28,6 +28,7 @@ scopes before running this example.
 """
 
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -55,6 +56,9 @@ from google.ads.googleads.v24.services.types.campaign_criterion_service import (
     CampaignCriterionOperation,
     MutateCampaignCriteriaResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, campaign_id: str) -> None:

--- a/examples/shopping_ads/add_performance_max_product_listing_group_tree.py
+++ b/examples/shopping_ads/add_performance_max_product_listing_group_tree.py
@@ -23,6 +23,7 @@ shopping_ads/add_performance_max_retail_campaign.py example.
 """
 
 import argparse
+import logging
 import sys
 from typing import Dict, List, Optional
 
@@ -45,6 +46,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
 from google.ads.googleads.v24.services.types.google_ads_service import (
     MutateOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # We specify temporary IDs that are specific to a single mutate request.
 # Temporary IDs are always negative and unique within one mutate request.

--- a/examples/shopping_ads/add_performance_max_retail_campaign.py
+++ b/examples/shopping_ads/add_performance_max_retail_campaign.py
@@ -36,6 +36,7 @@ Prerequisites:
 
 import argparse
 from datetime import datetime, timedelta
+import logging
 import sys
 from typing import Dict, List, Union
 from uuid import uuid4
@@ -106,6 +107,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
 from google.ads.googleads.v24.services.types.google_ads_service import (
     MutateOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # We specify temporary IDs that are specific to a single mutate request.
 # Temporary IDs are always negative and unique within one mutate request.

--- a/examples/shopping_ads/add_shopping_product_ad.py
+++ b/examples/shopping_ads/add_shopping_product_ad.py
@@ -25,6 +25,7 @@ This account must be linked to your Google Ads account.
 """
 
 import argparse
+import logging
 import sys
 import uuid
 
@@ -69,6 +70,9 @@ from google.ads.googleads.v24.services.types.campaign_budget_service import (
 from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/shopping_ads/add_shopping_product_listing_group_tree.py
+++ b/examples/shopping_ads/add_shopping_product_listing_group_tree.py
@@ -26,6 +26,7 @@ ProductCanonicalCondition null (everything else)
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Optional
 
@@ -57,6 +58,10 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     MutateGoogleAdsResponse,
     SearchGoogleAdsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 last_criterion_id: int = 0
 

--- a/examples/shopping_ads/get_product_category_constants.py
+++ b/examples/shopping_ads/get_product_category_constants.py
@@ -15,7 +15,7 @@
 """This example fetches the set of all ProductCategoryConstants."""
 
 import argparse
-import collections
+import logging
 import sys
 from typing import DefaultDict, List, Optional
 
@@ -31,6 +31,9 @@ from google.ads.googleads.v24.services.types.google_ads_service import (
     SearchGoogleAdsStreamRequest,
     SearchGoogleAdsStreamResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 class Category:

--- a/examples/targeting/add_campaign_targeting_criteria.py
+++ b/examples/targeting/add_campaign_targeting_criteria.py
@@ -15,8 +15,9 @@
 """This example adds campaign targeting criteria."""
 
 import argparse
-from typing import List
+import logging
 import sys
+from typing import List
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -39,6 +40,9 @@ from google.ads.googleads.v24.services.types.campaign_criterion_service import (
     CampaignCriterionOperation,
     MutateCampaignCriteriaResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/targeting/add_customer_negative_criteria.py
+++ b/examples/targeting/add_customer_negative_criteria.py
@@ -18,6 +18,7 @@ These criteria will be applied to all campaigns for the given customer.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -32,6 +33,9 @@ from google.ads.googleads.v24.services.types.customer_negative_criterion_service
     CustomerNegativeCriterionOperation,
     MutateCustomerNegativeCriteriaResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str) -> None:

--- a/examples/targeting/add_demographic_targeting_criteria.py
+++ b/examples/targeting/add_demographic_targeting_criteria.py
@@ -17,6 +17,7 @@ positive ad group criterion and one as negative ad group criterion. To
 create ad groups, run add_ad_groups.py."""
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -34,6 +35,9 @@ from google.ads.googleads.v24.services.types.ad_group_criterion_service import (
     AdGroupCriterionOperation,
     MutateAdGroupCriteriaResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(client: GoogleAdsClient, customer_id: str, ad_group_id: str) -> None:

--- a/examples/targeting/get_geo_target_constants_by_names.py
+++ b/examples/targeting/get_geo_target_constants_by_names.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """This example illustrates getting GeoTargetConstants by given location names."""
 
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -29,6 +30,10 @@ from google.ads.googleads.v24.services.types.geo_target_constant_service import 
     SuggestGeoTargetConstantsRequest,
     SuggestGeoTargetConstantsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # Locale is using ISO 639-1 format. If an invalid locale is given,
 # 'en' is used by default.

--- a/examples/travel/add_hotel_ad.py
+++ b/examples/travel/add_hotel_ad.py
@@ -21,6 +21,7 @@ https://support.google.com/hotelprices/answer/6101897.
 """
 
 import argparse
+import logging
 import sys
 import uuid
 
@@ -60,6 +61,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
     MutateCampaignsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/examples/travel/add_hotel_ad_group_bid_modifiers.py
+++ b/examples/travel/add_hotel_ad_group_bid_modifiers.py
@@ -18,6 +18,7 @@ The bid modifiers will be based on hotel check-in day and length of stay.
 """
 
 import argparse
+import logging
 import sys
 
 from google.ads.googleads.client import GoogleAdsClient
@@ -37,6 +38,9 @@ from google.ads.googleads.v24.services.types.ad_group_bid_modifier_service impor
     MutateAdGroupBidModifierResult,
     MutateAdGroupBidModifiersResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 # [START add_hotel_ad_group_bid_modifiers]

--- a/examples/travel/add_hotel_listing_group_tree.py
+++ b/examples/travel/add_hotel_listing_group_tree.py
@@ -29,6 +29,7 @@ listing group tree to an ad group that already has one will fail.
 """
 
 import argparse
+import logging
 import sys
 from typing import List, Optional
 
@@ -52,6 +53,10 @@ from google.ads.googleads.v24.services.types.ad_group_criterion_service import (
     MutateAdGroupCriteriaResponse,
     MutateAdGroupCriterionResult,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 # The next temporary criterion ID to be used, which is a negative integer.
 #

--- a/examples/travel/add_performance_max_for_travel_goals_campaign.py
+++ b/examples/travel/add_performance_max_for_travel_goals_campaign.py
@@ -36,6 +36,7 @@ Notes:
 """
 
 import argparse
+import logging
 import sys
 from typing import Dict, List
 
@@ -89,6 +90,10 @@ from google.ads.googleads.v24.services.types.travel_asset_suggestion_service imp
     SuggestTravelAssetsRequest,
     SuggestTravelAssetsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 MIN_REQUIRED_TEXT_ASSET_COUNTS: Dict[str, int] = {
     "HEADLINE": 3,

--- a/examples/travel/add_things_to_do_ad.py
+++ b/examples/travel/add_things_to_do_ad.py
@@ -20,6 +20,7 @@ https://support.google.com/google-ads/answer/13387362
 """
 
 import argparse
+import logging
 import sys
 
 from examples.utils.example_helpers import get_printable_datetime
@@ -59,6 +60,9 @@ from google.ads.googleads.v24.services.types.campaign_service import (
     CampaignOperation,
     MutateCampaignsResponse,
 )
+
+logger = logging.getLogger("google.ads.googleads.client")
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def main(

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -569,6 +569,9 @@ class GoogleAdsClientTest(TestCase):
                 name
                 for name in os.listdir(services_filepath)
                 if name.endswith("_service")
+                and os.path.isfile(
+                    os.path.join(services_filepath, name, "client.py")
+                )
             ]
 
             client = self._create_test_client(version=ver)
@@ -596,6 +599,9 @@ class GoogleAdsClientTest(TestCase):
                 name
                 for name in os.listdir(services_filepath)
                 if name.endswith("_service")
+                and os.path.isfile(
+                    os.path.join(services_filepath, name, "async_client.py")
+                )
             ]
 
             client = self._create_test_client(version=ver)


### PR DESCRIPTION
Add logging setup to the examples so that the client library configuration carries over when examples are executed.